### PR TITLE
Parsing errors even for non required files

### DIFF
--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -95,11 +95,6 @@ impl<T: FileSource> Source for File<T> {
             }
         });
 
-        if result.is_err() && !self.required {
-            // Ignore fails and just go with it if its not required
-            Ok(HashMap::new())
-        } else {
-            result
-        }
+        result
     }
 }


### PR DESCRIPTION
Related to #32
Even if a configuration file is not required, returns an error if
the file exists but the parsing failed.