### PR TITLE
Make boxed errors Send + Sync

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -50,7 +50,7 @@ pub enum ConfigError {
 
         /// The captured error from attempting to parse the file in its desired format.
         /// This is the actual error object from the library used for the parsing.
-        cause: Box<Error>
+        cause: Box<Error + Send + Sync>
     },
 
     /// Value could not be converted into the requested type.
@@ -75,7 +75,7 @@ pub enum ConfigError {
     Message(String),
 
     /// Unadorned error from a foreign origin.
-    Foreign(Box<Error>),
+    Foreign(Box<Error + Send + Sync>),
 }
 
 impl ConfigError {

--- a/src/file/format/json.rs
+++ b/src/file/format/json.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use value::{Value, ValueKind};
 
-pub fn parse(uri: Option<&String>, text: &str) -> Result<HashMap<String, Value>, Box<Error>> {
+pub fn parse(uri: Option<&String>, text: &str) -> Result<HashMap<String, Value>, Box<Error + Send + Sync>> {
     // Parse a JSON object value from the text
     // TODO: Have a proper error fire if the root of a file is ever not a Table
     let value = from_json_value(uri, &serde_json::from_str(text)?);

--- a/src/file/format/mod.rs
+++ b/src/file/format/mod.rs
@@ -66,7 +66,7 @@ impl FileFormat {
     pub fn parse(&self,
                  uri: Option<&String>,
                  text: &str)
-                 -> Result<HashMap<String, Value>, Box<Error>> {
+                 -> Result<HashMap<String, Value>, Box<Error + Send + Sync>> {
         match *self {
             #[cfg(feature = "toml")]
             FileFormat::Toml => toml::parse(uri, text),

--- a/src/file/format/toml.rs
+++ b/src/file/format/toml.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, BTreeMap};
 use std::error::Error;
 use value::{Value, ValueKind};
 
-pub fn parse(uri: Option<&String>, text: &str) -> Result<HashMap<String, Value>, Box<Error>> {
+pub fn parse(uri: Option<&String>, text: &str) -> Result<HashMap<String, Value>, Box<Error + Send + Sync>> {
     // Parse a TOML value from the provided text
     // TODO: Have a proper error fire if the root of a file is ever not a Table
     let value = from_toml_value(uri, &toml::from_str(text)?);

--- a/src/file/format/yaml.rs
+++ b/src/file/format/yaml.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::mem;
 use value::{Value, ValueKind};
 
-pub fn parse(uri: Option<&String>, text: &str) -> Result<HashMap<String, Value>, Box<Error>> {
+pub fn parse(uri: Option<&String>, text: &str) -> Result<HashMap<String, Value>, Box<Error + Send + Sync>> {
     // Parse a YAML object from file
     let mut docs = yaml::YamlLoader::load_from_str(text)?;
     let root = match docs.len() {

--- a/src/file/source/file.rs
+++ b/src/file/source/file.rs
@@ -26,7 +26,7 @@ impl FileSourceFile {
 
     fn find_file(&self,
                  format_hint: Option<FileFormat>)
-                 -> Result<(PathBuf, FileFormat), Box<Error>> {
+                 -> Result<(PathBuf, FileFormat), Box<Error + Send + Sync>> {
         // First check for an _exact_ match
         let mut filename = env::current_dir()?.as_path().join(self.name.clone());
         if filename.is_file() {
@@ -83,7 +83,7 @@ impl FileSourceFile {
 impl FileSource for FileSourceFile {
     fn resolve(&self,
                format_hint: Option<FileFormat>)
-               -> Result<(Option<String>, String, FileFormat), Box<Error>> {
+               -> Result<(Option<String>, String, FileFormat), Box<Error + Send + Sync>> {
         // Find file
         let (filename, format) = self.find_file(format_hint)?;
 

--- a/src/file/source/mod.rs
+++ b/src/file/source/mod.rs
@@ -11,5 +11,5 @@ use super::FileFormat;
 pub trait FileSource: Debug + Clone {
     fn resolve(&self,
                format_hint: Option<FileFormat>)
-               -> Result<(Option<String>, String, FileFormat), Box<Error>>;
+               -> Result<(Option<String>, String, FileFormat), Box<Error + Send + Sync>>;
 }

--- a/src/file/source/string.rs
+++ b/src/file/source/string.rs
@@ -18,7 +18,7 @@ impl<'a> From<&'a str> for FileSourceString {
 impl FileSource for FileSourceString {
     fn resolve(&self,
                format_hint: Option<FileFormat>)
-               -> Result<(Option<String>, String, FileFormat), Box<Error>> {
+               -> Result<(Option<String>, String, FileFormat), Box<Error + Send + Sync>> {
         Ok((None, self.0.clone(), format_hint.expect("from_str requires a set file format")))
     }
 }


### PR DESCRIPTION
This PR makes `ConfigError` play nicely with crates such as `error-chain` which require an error type to be `Send` by changing all `Box<Error>` into `Box<Error + Send + Sync>` and thereby making `ConfigError: Sync + Send`. The `Sync` is there because the standard library only implements:

```rust
impl<'a, E: Error + 'a> From<E> for Box<Error + 'a> {}
impl<'a, E: Error + Send + Sync + 'a> From<E> for Box<Error + Send + Sync + 'a> {}
```

This should not be a problem though, since almost all error types implement both `Sync` and `Send`, including the ones used by this crate.