### PR TITLE
Fix markdown lists

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Config lets you set a set of default parameters and then extend them via merging in
 //! configuration from a variety of sources:
+//!
 //!  - Environment variables
 //!  - Another Config instance
 //!  - Remote configuration: etcd, Consul
@@ -9,6 +10,7 @@
 //!  - Manual, programmatic override (via a `.set` method on the Config instance)
 //!
 //! Additionally, Config supports:
+//!
 //!  - Live watching and re-reading of configuration files
 //!  - Deep access into the merged configuration via a path syntax
 //!  - Deserialization via `serde` of the configuration or any subset defined via a path


### PR DESCRIPTION
The lists were wrongly formatted. In markdown, the lists needs a free line before and after them.