### PR TITLE
Be compatible with nom's "verbose-errors" feature

### DIFF
--- a/src/path/parser.rs
+++ b/src/path/parser.rs
@@ -63,9 +63,9 @@ pub fn from_str(input: &str) -> Result<Expression, ErrorKind> {
                         expr = expr_;
                     }
 
-                    // Forward Incomplete and Error
+                    // Forward Error, panic on incomplete
                     result => {
-                        return result.to_result();
+                        return result.to_result().map_err(Err::into_error_kind);
                     }
                 }
             }
@@ -73,8 +73,8 @@ pub fn from_str(input: &str) -> Result<Expression, ErrorKind> {
             Ok(expr)
         }
 
-        // Forward Incomplete and Error
-        result => result.to_result(),
+        // Forward Error, panic on incomplete
+        result => result.to_result().map_err(Err::into_error_kind),
     }
 }
 


### PR DESCRIPTION
See https://users.rust-lang.org/t/shared-dependencies-and-incompatible-features/15145

It's kind of hard to test if this really works since you'd need to run the test suite twice, once like normal, and once with `--features nom/verbose-errors`.

I also noticed the comments on the `to_result` conversion were incorrect with regards to what nom actually does. Not sure if you wanted the behavior specified, but that would require some different code. For now I just changed the comments.