### PR TITLE
update to nom 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hjson = ["serde-hjson"]
 [dependencies]
 lazy_static = "1.0"
 serde = "^1.0.8"
-nom = "^3.2.1"
+nom = "4.0.0-beta1"
 
 toml = { version = "^0.4.1", optional = true }
 serde_json = { version = "^1.0.2", optional = true }

--- a/src/path/parser.rs
+++ b/src/path/parser.rs
@@ -55,17 +55,17 @@ fn postfix(expr: Expression) -> Box<Fn(&[u8]) -> IResult<&[u8], Expression>> {
 
 pub fn from_str(input: &str) -> Result<Expression, ErrorKind> {
     match ident(input.as_bytes()) {
-        IResult::Done(mut rem, mut expr) => {
+        Ok((mut rem, mut expr)) => {
             while !rem.is_empty() {
                 match postfix(expr)(rem) {
-                    IResult::Done(rem_, expr_) => {
+                    Ok((rem_, expr_)) => {
                         rem = rem_;
                         expr = expr_;
                     }
 
                     // Forward Incomplete and Error
                     result => {
-                        return result.to_result().map_err(|e| e.into_error_kind());
+                        return result.map(|(_,o)| o).map_err(|e| e.into_error_kind());
                     }
                 }
             }
@@ -74,7 +74,7 @@ pub fn from_str(input: &str) -> Result<Expression, ErrorKind> {
         }
 
         // Forward Incomplete and Error
-        result => result.to_result().map_err(|e| e.into_error_kind()),
+        result => result.map(|(_,o)| o).map_err(|e| e.into_error_kind()),
     }
 }
 


### PR DESCRIPTION
Hello,

I'm currently testing the upgrade to nom 4 on various crates, to see if I forgot anything. Currently, I get these error after doing the following changes:

```
[Running 'cargo test']
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running target/debug/deps/config-a0903495d12738cd

running 5 tests
test path::parser::test::test_subscript ... ok
test path::parser::test::test_subscript_neg ... ok
test path::parser::test::test_child ... FAILED
test path::parser::test::test_id_dash ... FAILED
test path::parser::test::test_id ... FAILED

failures:

---- path::parser::test::test_child stdout ----
        thread 'path::parser::test::test_child' panicked at 'called `Result::unwrap()` on an `Err` value: Complete', libcore/result.rs:945:5

---- path::parser::test::test_id_dash stdout ----
        thread 'path::parser::test::test_id_dash' panicked at 'called `Result::unwrap()` on an `Err` value: Complete', libcore/result.rs:945:5

---- path::parser::test::test_id stdout ----
        thread 'path::parser::test::test_id' panicked at 'called `Result::unwrap()` on an `Err` value: Complete', libcore/result.rs:945:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.


failures:
    path::parser::test::test_child
    path::parser::test::test_id
    path::parser::test::test_id_dash

test result: FAILED. 2 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out

error: test failed, to rerun pass '--lib'
```

They are probably linked to [the new behaviour around partial data](https://github.com/Geal/nom/blob/master/doc/upgrading_to_nom_4.md#dealing-with-incomplete-usage). It requires changing the input types, but makes all parsers easier to write.