### PR TITLE
Deserialize newtype struct

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -224,9 +224,16 @@ impl<'de> de::Deserializer<'de> for Value {
         }
     }
 
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
     forward_to_deserialize_any! {
         char seq
-        bytes byte_buf map struct unit enum newtype_struct
+        bytes byte_buf map struct unit enum
         identifier ignored_any unit_struct tuple_struct tuple
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -119,17 +119,17 @@ pub struct Value {
     /// A description of the original location of the value.
     ///
     /// A Value originating from a File might contain:
-    /// ```
+    /// ```text
     /// Settings.toml
     /// ```
     ///
     /// A Value originating from the environment would contain:
-    /// ```
+    /// ```text
     /// the envrionment
     /// ```
     ///
     /// A Value originating from a remote source might contain:
-    /// ```
+    /// ```text
     /// etcd+http://127.0.0.1:2379
     /// ```
     origin: Option<String>,

--- a/tests/Settings.toml
+++ b/tests/Settings.toml
@@ -3,6 +3,8 @@ debug_s = "true"
 production = false
 production_s = "false"
 
+code = 53
+
 # errors
 boolean_s_parse = "fals"
 
@@ -15,6 +17,7 @@ name = "1"
 name = "2"
 
 [place]
+number = 1
 name = "Torre di Pisa"
 longitude = 43.7224985
 latitude = 10.3970522

--- a/tests/file_hjson.rs
+++ b/tests/file_hjson.rs
@@ -43,7 +43,7 @@ fn test_file() {
     let c = make();
 
     // Deserialize the entire file as single struct
-    let s: Settings = c.deserialize().unwrap();
+    let s: Settings = c.try_into().unwrap();
 
     assert!(s.debug.approx_eq_ulps(&1.0, 2));
     assert_eq!(s.production, Some("false".to_string()));

--- a/tests/file_json.rs
+++ b/tests/file_json.rs
@@ -43,7 +43,7 @@ fn test_file() {
     let c = make();
 
     // Deserialize the entire file as single struct
-    let s: Settings = c.deserialize().unwrap();
+    let s: Settings = c.try_into().unwrap();
 
     assert!(s.debug.approx_eq_ulps(&1.0, 2));
     assert_eq!(s.production, Some("false".to_string()));

--- a/tests/file_toml.rs
+++ b/tests/file_toml.rs
@@ -11,6 +11,7 @@ use config::*;
 
 #[derive(Debug, Deserialize)]
 struct Place {
+    number: PlaceNumber,
     name: String,
     longitude: f64,
     latitude: f64,
@@ -21,10 +22,17 @@ struct Place {
     rating: Option<f32>,
 }
 
+#[derive(Debug, Deserialize, PartialEq)]
+struct PlaceNumber(u8);
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct AsciiCode(i8);
+
 #[derive(Debug, Deserialize)]
 struct Settings {
     debug: f64,
     production: Option<String>,
+    code: AsciiCode,
     place: Place,
     #[serde(rename = "arr")]
     elements: Vec<String>,
@@ -47,6 +55,8 @@ fn test_file() {
 
     assert!(s.debug.approx_eq_ulps(&1.0, 2));
     assert_eq!(s.production, Some("false".to_string()));
+    assert_eq!(s.code, AsciiCode(53));
+    assert_eq!(s.place.number, PlaceNumber(1));
     assert_eq!(s.place.name, "Torre di Pisa");
     assert!(s.place.longitude.approx_eq_ulps(&43.7224985, 2));
     assert!(s.place.latitude.approx_eq_ulps(&10.3970522, 2));

--- a/tests/file_toml.rs
+++ b/tests/file_toml.rs
@@ -51,7 +51,7 @@ fn test_file() {
     let c = make();
 
     // Deserialize the entire file as single struct
-    let s: Settings = c.deserialize().unwrap();
+    let s: Settings = c.try_into().unwrap();
 
     assert!(s.debug.approx_eq_ulps(&1.0, 2));
     assert_eq!(s.production, Some("false".to_string()));

--- a/tests/file_yaml.rs
+++ b/tests/file_yaml.rs
@@ -43,7 +43,7 @@ fn test_file() {
     let c = make();
 
     // Deserialize the entire file as single struct
-    let s: Settings = c.deserialize().unwrap();
+    let s: Settings = c.try_into().unwrap();
 
     assert!(s.debug.approx_eq_ulps(&1.0, 2));
     assert_eq!(s.production, Some("false".to_string()));

--- a/tests/get.rs
+++ b/tests/get.rs
@@ -107,7 +107,7 @@ fn test_map() {
     let c = make();
     let m: HashMap<String, Value> = c.get("place").unwrap();
 
-    assert_eq!(m.len(), 7);
+    assert_eq!(m.len(), 8);
     assert_eq!(
         m["name"].clone().into_str().unwrap(),
         "Torre di Pisa".to_string()
@@ -134,7 +134,7 @@ fn test_map_struct() {
     let c = make();
     let s: Settings = c.try_into().unwrap();
 
-    assert_eq!(s.place.len(), 7);
+    assert_eq!(s.place.len(), 8);
     assert_eq!(
         s.place["name"].clone().into_str().unwrap(),
         "Torre di Pisa".to_string()


### PR DESCRIPTION
Close #70 

This fixes the linked issue.
I have picked the code from corresponding [`toml-rs`](https://github.com/alexcrichton/toml-rs/blob/master/src/value.rs#L547-L555) part.
There are another `Deserializer` impls in the same file, not sure if the same should be done for them too.

Please, feel free to provide any comments.