### PR TITLE
Treat empty environment variables as unset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ json = ["serde_json"]
 yaml = ["yaml-rust"]
 hjson = ["serde-hjson"]
 ini = ["rust-ini"]
+ignore-empty-env-vars = []
 
 [dependencies]
 lazy_static = "1.0"

--- a/src/env.rs
+++ b/src/env.rs
@@ -74,6 +74,11 @@ impl Source for Environment {
         };
 
         for (key, value) in env::vars() {
+            // Treat empty environment variables as unset
+            if cfg!(feature = "ignore-empty-env-vars") && value == "" {
+                continue;
+            }
+
             let mut key = key.to_string();
 
             // Check for prefix

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -60,3 +60,15 @@ fn test_separator_behavior() {
 
     env::remove_var("C_B_A");
 }
+
+#[test]
+#[cfg(feature = "ignore-empty-env-vars")]
+fn test_empty_value_is_ignored() {
+    env::set_var("C_A_B", "");
+
+    let environment = Environment::new();
+
+    assert!(!environment.collect().unwrap().contains_key("c_a_b"));
+
+    env::remove_var("C_A_B");
+}


### PR DESCRIPTION
Not sure what you'll think of this change, but it comes from [a request from our ops folk](https://github.com/mozilla/fxa-email-service/issues/191). Essentially they were expecting an empty environment variable to fall back to the default value rather than overwrite it.

From an abundance of caution it's conditionally compiled behind a feature flag, as I presume it will be a breaking change for some people. Is there any chance of landing this (or something like it)?