### PR TITLE
Update serde-hjson dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ nom = "4.0.0"
 toml = { version = "0.4.1", optional = true }
 serde_json = { version = "1.0.2", optional = true }
 yaml-rust = { version = "0.4", optional = true }
-serde-hjson = { version = "0.8.1", optional = true }
+serde-hjson = { version = "0.8.2", optional = true }
 rust-ini = { version = "0.13", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
serde-hjson update the outdated regex dependency in this version. This should make a cleaner dependency tree.