### PR TITLE
upgrade serde-hjson to v0.8.2 so we can have consistent error check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ nom = "4.0.0"
 toml = { version = "0.4.1", optional = true }
 serde_json = { version = "1.0.2", optional = true }
 yaml-rust = { version = "0.4", optional = true }
-serde-hjson = { version = "0.8.1", optional = true }
+serde-hjson = { version = "0.8.2", optional = true }
 rust-ini = { version = "0.13", optional = true }
 
 [dev-dependencies]

--- a/tests/file_hjson.rs
+++ b/tests/file_hjson.rs
@@ -72,6 +72,6 @@ fn test_error_parse() {
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        "Found a punctuator where a key name was expected (check your syntax or use quotes if the key name includes {}[],: or whitespace) at line 1 column 1 in tests/Settings-invalid.hjson".to_string()
+        "Found a punctuator where a key name was expected (check your syntax or use quotes if the key name includes {}[],: or whitespace) at line 4 column 1 in tests/Settings-invalid.hjson".to_string()
     );
 }


### PR DESCRIPTION
We had unfortunate situation where errors emitted by serde-hjson where different or v0.8.1 and v0.8.2. And we are expecting those errors in our test cases, so such a change is breaking for us. But as in semver terms minor version does not break, users could freely upgrade and then our tests failed (see travis).

That is the reasoning behind this version bump.  