### PR TITLE
Update example deprecated method

### DIFF
--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -13,5 +13,5 @@ fn main() {
 
     // Print out our settings (as a HashMap)
     println!("{:?}",
-             settings.deserialize::<HashMap<String, String>>().unwrap());
+             settings.try_into::<HashMap<String, String>>().unwrap());
 }


### PR DESCRIPTION
Update deprecated `deserialize` to use the preferred `try_into`.