### PR TITLE
Added HOCON as a config file format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "mehcode/config-rs" }
 
 [features]
-default = ["toml", "json", "yaml", "hjson", "ini"]
+default = ["toml", "json", "yaml", "hjson", "ini", "hocon"]
 json = ["serde_json"]
 yaml = ["yaml-rust"]
 hjson = ["serde-hjson"]
@@ -30,6 +30,7 @@ serde_json = { version = "1.0.2", optional = true }
 yaml-rust = { version = "0.4", optional = true }
 serde-hjson = { version = "0.8.2", optional = true }
 rust-ini = { version = "0.13", optional = true }
+hocon = { version = "0.3", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_derive = "1.0.8"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
  - Set defaults
  - Set explicit values (to programmatically override)
- - Read from [JSON], [TOML], [YAML], [HJSON], [INI] files
+ - Read from [JSON], [TOML], [YAML], [HJSON], [INI], [HOCON] files
  - Read from environment
  - Loosely typed — Configuration values may be read in any supported type, as long as there exists a reasonable conversion
  - Access nested fields using a formatted path — Uses a subset of JSONPath; currently supports the child ( `redis.port` ) and subscript operators ( `databases[0].name` )
@@ -20,6 +20,7 @@
 [YAML]: https://github.com/chyh1990/yaml-rust
 [HJSON]: https://github.com/hjson/hjson-rust
 [INI]: https://github.com/zonyitoo/rust-ini
+[HOCON]: https://github.com/mockersf/hocon.rs
 
 ## Usage
 
@@ -33,6 +34,7 @@ config = "0.9"
  - `hjson` - Adds support for reading HJSON files
  - `yaml` - Adds support for reading YAML files
  - `toml` - Adds support for reading TOML files
+ - `hocon` - Adds support for reading HOCON files
 
 See the [documentation](https://docs.rs/config) or [examples](https://github.com/mehcode/config-rs/tree/master/examples) for
 more usage information.

--- a/src/file/format/hocon.rs
+++ b/src/file/format/hocon.rs
@@ -1,0 +1,56 @@
+use hocon;
+use source::Source;
+use std::collections::HashMap;
+use std::error::Error;
+use value::{Value, ValueKind};
+
+pub fn parse(
+    uri: Option<&String>,
+    text: &str,
+) -> Result<HashMap<String, Value>, Box<Error + Send + Sync>> {
+    let loaded = if let Some(uri) = uri {
+        hocon::HoconLoader::new().load_file(uri)
+    } else {
+        hocon::HoconLoader::new().load_str(text)
+    };
+    let value = from_hocon_value(uri, &loaded?.hocon()?);
+
+    match value.kind {
+        ValueKind::Table(map) => Ok(map),
+        _ => Ok(HashMap::new()),
+    }
+}
+
+fn from_hocon_value(uri: Option<&String>, value: &hocon::Hocon) -> Value {
+    match *value {
+        hocon::Hocon::Integer(ref value) => Value::new(uri, ValueKind::Integer(*value)),
+
+        hocon::Hocon::Real(ref value) => Value::new(uri, ValueKind::Float(*value)),
+
+        hocon::Hocon::Boolean(ref value) => Value::new(uri, ValueKind::Boolean(*value)),
+
+        hocon::Hocon::String(ref value) => Value::new(uri, ValueKind::String(value.clone())),
+
+        hocon::Hocon::Hash(ref table) => {
+            let mut m = HashMap::new();
+
+            for (key, value) in table {
+                m.insert(key.to_lowercase().clone(), from_hocon_value(uri, value));
+            }
+
+            Value::new(uri, ValueKind::Table(m))
+        }
+
+        hocon::Hocon::Array(ref array) => {
+            let mut l = Vec::new();
+
+            for value in array {
+                l.push(from_hocon_value(uri, value));
+            }
+
+            Value::new(uri, ValueKind::Array(l))
+        }
+
+        hocon::Hocon::Null | hocon::Hocon::BadValue(_) => Value::new(uri, ValueKind::Nil),
+    }
+}

--- a/src/file/format/mod.rs
+++ b/src/file/format/mod.rs
@@ -22,6 +22,9 @@ mod hjson;
 #[cfg(feature = "ini")]
 mod ini;
 
+#[cfg(feature = "hocon")]
+mod hocon;
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum FileFormat {
     /// TOML (parsed with toml)
@@ -42,6 +45,9 @@ pub enum FileFormat {
     /// INI (parsed with rust_ini)
     #[cfg(feature = "ini")]
     Ini,
+    /// HOCON (parsed with rust_ini)
+    #[cfg(feature = "hocon")]
+    Hocon,
 }
 
 lazy_static! {
@@ -64,6 +70,9 @@ lazy_static! {
 
         #[cfg(feature = "ini")]
         formats.insert(FileFormat::Ini, vec!["ini"]);
+
+        #[cfg(feature = "hocon")]
+        formats.insert(FileFormat::Hocon, vec!["conf"]);
 
         formats
     };
@@ -102,6 +111,9 @@ impl FileFormat {
 
             #[cfg(feature = "ini")]
             FileFormat::Ini => ini::parse(uri, text),
+
+            #[cfg(feature = "hocon")]
+            FileFormat::Hocon => hocon::parse(uri, text),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@ extern crate serde_hjson;
 #[cfg(feature = "ini")]
 extern crate ini;
 
+#[cfg(feature = "hocon")]
+extern crate hocon;
+
 mod config;
 mod de;
 mod env;

--- a/tests/Settings-invalid.conf
+++ b/tests/Settings-invalid.conf
@@ -1,0 +1,4 @@
+{
+  "ok": true,
+  "error"
+}

--- a/tests/Settings.conf
+++ b/tests/Settings.conf
@@ -1,0 +1,16 @@
+debug = true
+production = false
+arr = [1, 2, 3, 4, 5]
+arr = ${arr} [6, 7, 8, 9]
+arr += 10
+place {
+  name = Torre di Pisa
+  longitude = 43.7224985
+  latitude = 10.3970522
+  reviews = 3866
+  rating = 4.6
+  creator.name = John Smith
+}
+place.favorite = false
+
+json-included = include "Settings.json"

--- a/tests/file_hocon.rs
+++ b/tests/file_hocon.rs
@@ -1,0 +1,80 @@
+#![cfg(feature = "hocon")]
+
+extern crate config;
+extern crate float_cmp;
+extern crate serde;
+
+#[macro_use]
+extern crate serde_derive;
+
+use config::*;
+use float_cmp::ApproxEqUlps;
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize)]
+struct Place {
+    name: String,
+    longitude: f64,
+    latitude: f64,
+    favorite: bool,
+    telephone: Option<String>,
+    reviews: u64,
+    creator: HashMap<String, Value>,
+    rating: Option<f32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Settings {
+    debug: f64,
+    production: Option<String>,
+    place: Place,
+    #[serde(rename = "arr")]
+    elements: Vec<String>,
+    #[serde(rename = "json-included")]
+    json: Option<Box<Settings>>,
+}
+
+fn make() -> Config {
+    let mut c = Config::default();
+    c.merge(File::new("tests/Settings", FileFormat::Hocon))
+        .unwrap();
+
+    c
+}
+
+#[test]
+fn test_file() {
+    let c = make();
+
+    // Deserialize the entire file as single struct
+    let s: Settings = c.try_into().unwrap();
+
+    assert!(s.debug.approx_eq_ulps(&1.0, 2));
+    assert_eq!(s.production, Some("false".to_string()));
+    assert_eq!(s.place.name, "Torre di Pisa");
+    assert!(s.place.longitude.approx_eq_ulps(&43.7224985, 2));
+    assert!(s.place.latitude.approx_eq_ulps(&10.3970522, 2));
+    assert_eq!(s.place.favorite, false);
+    assert_eq!(s.place.reviews, 3866);
+    assert_eq!(s.place.rating, Some(4.6));
+    assert_eq!(s.place.telephone, None);
+    assert_eq!(s.elements.len(), 10);
+    assert_eq!(s.elements[3], "4".to_string());
+    assert_eq!(
+        s.place.creator["name"].clone().into_str().unwrap(),
+        "John Smith".to_string()
+    );
+    assert_eq!(s.json.unwrap().place.rating, Some(4.5));
+}
+
+#[test]
+fn test_error_parse() {
+    let mut c = Config::default();
+    let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Hocon));
+
+    assert!(res.is_err());
+    assert_eq!(
+        res.unwrap_err().to_string(),
+        "Error wile parsing document in tests/Settings-invalid.conf".to_string()
+    );
+}


### PR DESCRIPTION
Default features of the hocon library are disabled.

The two features disabled are:
* serde support, which this crate already does
* `include url(...)` hocon syntax support, which needs a dependency on `reqwest` even though it won't be used in most cases