### PR TITLE
Fix defaults serialization and 'invalid type: unit value' deserialization error (#60)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@ use ser::ConfigSerializer;
 use source::Source;
 
 use path;
-use value::{Value, ValueKind, ValueWithKey};
+use value::{Table, Value, ValueKind, ValueWithKey};
 
 #[derive(Clone, Debug)]
 enum ConfigKind {
@@ -49,7 +49,12 @@ pub struct Config {
 
 impl Config {
     pub fn new() -> Self {
-        Config::default()
+        Self {
+            kind: ConfigKind::default(),
+            // Config root should be instantiated as an empty table
+            // to avoid deserialization errors.
+            cache: Value::new(None, Table::new()),
+        }
     }
 
     /// Merge in a configuration property source.

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,6 +134,7 @@ impl Config {
         self.refresh()
     }
 
+    /// Set the configuration defaults by serializing them from given value.
     pub fn set_defaults<T>(&mut self, value: &T) -> Result<&mut Config>
     where
         T: Serialize,

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -1,0 +1,36 @@
+extern crate config;
+
+#[macro_use]
+extern crate serde_derive;
+
+use config::*;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Settings {
+    pub db_host: String,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Settings {
+            db_host: String::from("default"),
+        }
+    }
+}
+
+#[test]
+fn set_defaults() {
+    let mut c = Config::new();
+    c.set_defaults(&Settings::default())
+        .expect("Setting defaults failed");
+    let s: Settings = c.try_into().expect("Deserialization failed");
+
+    assert_eq!(s.db_host, "default");
+}
+
+#[test]
+fn try_from_defaults() {
+    let c = Config::try_from(&Settings::default()).expect("Serialization failed");
+    let s: Settings = c.try_into().expect("Deserialization failed");
+    assert_eq!(s.db_host, "default");
+}

--- a/tests/empty.rs
+++ b/tests/empty.rs
@@ -1,0 +1,21 @@
+extern crate config;
+
+#[macro_use]
+extern crate serde_derive;
+
+use config::*;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Settings {
+    #[serde(skip)]
+    foo: isize,
+    #[serde(skip)]
+    bar: u8,
+}
+
+#[test]
+fn empty_deserializes() {
+    let s: Settings = Config::new().try_into().expect("Deserialization failed");
+    assert_eq!(s.foo, 0);
+    assert_eq!(s.bar, 0);
+}


### PR DESCRIPTION
A second attempt to fix #60  

Dupe of #95, but tries to follow the [feedback](https://github.com/mehcode/config-rs/pull/95#issuecomment-473707753). 

## Background

As @vorner [wrote](https://github.com/mehcode/config-rs/issues/60#issuecomment-413663545):
> I think there are two issues here, aren't there?
>
> First one is how to use defaults ‒ and the answer for that one is to use the serde's default handling (eg. the default attribute on fields).
>
> The other problem is the annoying unit value error. I managed to work around that one by merging an empty source as the first one, eg config.merge(File::from_str("", FileFormat::Toml))?. Could something like this be already done as part of the constructor? I mean, make sure whatever is tried to be deserialized looks like an empty map to serde, not unit.


## Solution

1. The first issue is solved by providing two new methods:
    - `set_defaults(&mut self, val: &T) -> Result<&mut Self>`, `where T: Serialize`, which allows to mutate defaults values of `Config` by serializing them from given value.
    - `try_defaults_from(val: &T) -> Result<Self>`, `where T: Serialize`, which is the brother of `try_from()` but operates with `defaults` (not `overrides`).

2. The second issue is solved by creating empty `ValueKind::Table` rather than `ValueKind::Nil` as @derekdreery [pointed out](https://github.com/mehcode/config-rs/issues/60#issuecomment-473705663).


## Checklist

- [x] 1. Code style conformed.
- [x] 2. Tests are added.
- [x] 3. Documentation is added/corrected.