### PR TITLE
Make from_toml_value case sensitive

### DIFF
--- a/src/file/format/toml.rs
+++ b/src/file/format/toml.rs
@@ -29,7 +29,7 @@ fn from_toml_value(uri: Option<&String>, value: &toml::Value) -> Value {
             let mut m = HashMap::new();
 
             for (key, value) in table {
-                m.insert(key.to_lowercase().clone(), from_toml_value(uri, value));
+                m.insert(key.clone(), from_toml_value(uri, value));
             }
 
             Value::new(uri, m)


### PR DESCRIPTION
TOML is case sensitive [0], so key values should not be lowercased.

[0] https://github.com/toml-lang/toml#user-content-spec