### PR TITLE
port to nom 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ ini = ["rust-ini"]
 [dependencies]
 lazy_static = "1.0"
 serde = "1.0.8"
-nom = "4.0.0"
+nom = "5.0.0"
 
 toml = { version = "0.5", optional = true }
 serde_json = { version = "1.0.2", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,7 +41,7 @@ pub enum ConfigError {
     NotFound(String),
 
     /// Configuration path could not be parsed.
-    PathParse(nom::ErrorKind),
+    PathParse(nom::error::ErrorKind),
 
     /// Configuration could not be parsed from file.
     FileParse {

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -1,5 +1,5 @@
 use error::*;
-use nom::ErrorKind;
+use nom::error::ErrorKind;
 use std::collections::HashMap;
 use std::str::FromStr;
 use value::{Value, ValueKind};


### PR DESCRIPTION
hello, I took a look, there was not much to do to port it. Now it can work without `CompleteStr`. There might be another way to write `postfix` with cloning the expression before the closures, though