### PR TITLE
Enum key

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -151,9 +151,23 @@ impl<'de, 'a> de::Deserializer<'de> for StrDeserializer<'a> {
         visitor.visit_str(self.0)
     }
 
+    fn deserialize_enum<V: de::Visitor<'de>>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V
+    ) -> Result<V::Value> {
+        // FIXME: Is this a too much of an abuse of StrDeserializer? But it seems to work...
+        visitor.visit_enum(EnumAccess{
+            value: Value::new(None, self.0),
+            name: name,
+            variants: variants,
+        })
+    }
+
     forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
-        bytes byte_buf map struct unit enum newtype_struct
+        bytes byte_buf map struct unit newtype_struct
         identifier ignored_any unit_struct tuple_struct tuple option
     }
 }

--- a/tests/Settings.toml
+++ b/tests/Settings.toml
@@ -9,6 +9,7 @@ code = 53
 boolean_s_parse = "fals"
 
 arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+quarks = ["up", "down", "strange", "charm", "bottom", "top"]
 
 [diodes]
 green = "off"
@@ -40,3 +41,7 @@ rating = 4.5
 
 [place.creator]
 name = "John Smith"
+
+[proton]
+up = 2
+down = 1

--- a/tests/get.rs
+++ b/tests/get.rs
@@ -9,7 +9,7 @@ extern crate serde_derive;
 
 use config::*;
 use float_cmp::ApproxEqUlps;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Deserialize)]
 struct Place {
@@ -224,4 +224,30 @@ fn test_enum() {
     assert_eq!(s.diodes["red"], Diode::Brightness(100));
     assert_eq!(s.diodes["blue"], Diode::Blinking(300, 700));
     assert_eq!(s.diodes["white"], Diode::Pattern{name: "christmas".into(), inifinite: true,});
+}
+
+#[test]
+fn test_enum_key() {
+    #[derive(Debug, Deserialize, PartialEq, Eq, Hash)]
+    enum Quark {
+        Up,
+        Down,
+        Strange,
+        Charm,
+        Bottom,
+        Top,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Settings {
+        proton: HashMap<Quark, usize>,
+        // Just to make sure that set keys work too.
+        quarks: HashSet<Quark>,
+    }
+
+    let c = make();
+    let s: Settings = c.try_into().unwrap();
+
+    assert_eq!(s.proton[&Quark::Up], 2);
+    assert_eq!(s.quarks.len(), 6);
 }


### PR DESCRIPTION
This implements the enums as map keys from #74. This probably works only for simple (data-less) enums.

I hope this has no ill side effect to some other use case.