### PR TITLE
Allow arbitrary types of map keys

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -215,7 +215,7 @@ impl<'de> de::MapAccess<'de> for MapAccess {
         K: de::DeserializeSeed<'de>,
     {
         if let Some(&(ref key_s, _)) = self.elements.front() {
-            let key_de = StrDeserializer(key_s);
+            let key_de = Value::new(None, key_s as &str);
             let key = de::DeserializeSeed::deserialize(seed, key_de)?;
 
             Ok(Some(key))

--- a/tests/Settings.toml
+++ b/tests/Settings.toml
@@ -9,6 +9,7 @@ code = 53
 boolean_s_parse = "fals"
 
 arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+quarks = ["up", "down", "strange", "charm", "bottom", "top"]
 
 [diodes]
 green = "off"
@@ -40,3 +41,13 @@ rating = 4.5
 
 [place.creator]
 name = "John Smith"
+
+[proton]
+up = 2
+down = 1
+
+[divisors]
+1 = 1
+2 = 2
+4 = 3
+5 = 2

--- a/tests/get.rs
+++ b/tests/get.rs
@@ -9,7 +9,7 @@ extern crate serde_derive;
 
 use config::*;
 use float_cmp::ApproxEqUlps;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Deserialize)]
 struct Place {
@@ -224,4 +224,43 @@ fn test_enum() {
     assert_eq!(s.diodes["red"], Diode::Brightness(100));
     assert_eq!(s.diodes["blue"], Diode::Blinking(300, 700));
     assert_eq!(s.diodes["white"], Diode::Pattern{name: "christmas".into(), inifinite: true,});
+}
+
+#[test]
+fn test_enum_key() {
+    #[derive(Debug, Deserialize, PartialEq, Eq, Hash)]
+    enum Quark {
+        Up,
+        Down,
+        Strange,
+        Charm,
+        Bottom,
+        Top,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Settings {
+        proton: HashMap<Quark, usize>,
+        // Just to make sure that set keys work too.
+        quarks: HashSet<Quark>,
+    }
+
+    let c = make();
+    let s: Settings = c.try_into().unwrap();
+
+    assert_eq!(s.proton[&Quark::Up], 2);
+    assert_eq!(s.quarks.len(), 6);
+}
+
+#[test]
+fn test_int_key() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Settings {
+        divisors: HashMap<u32, u32>,
+    }
+
+    let c = make();
+    let s: Settings = c.try_into().unwrap();
+    assert_eq!(s.divisors[&4], 3);
+    assert_eq!(s.divisors.len(), 4);
 }


### PR DESCRIPTION
Of particular interest are maps that have numbers or enums as keys.

Closes #74.