### PR TITLE
feat: add optional toml feature to only depend on toml crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ travis-ci = { repository = "mehcode/config-rs" }
 
 [features]
 default = ["toml", "json", "yaml", "hjson", "ini"]
+toml = ["toml"]
 json = ["serde_json"]
 yaml = ["yaml-rust"]
 hjson = ["serde-hjson"]


### PR DESCRIPTION
I'd like to be able to include only the toml feature, but it's the only one that doesn't have a separate feature.