### PR TITLE
Apply clippy suggestions

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ enum ConfigKind {
     Mutable {
         defaults: HashMap<path::Expression, Value>,
         overrides: HashMap<path::Expression, Value>,
-        sources: Vec<Box<Source + Send + Sync>>,
+        sources: Vec<Box<dyn Source + Send + Sync>>,
     },
 
     // A frozen configuration.
@@ -212,7 +212,7 @@ impl Config {
 }
 
 impl Source for Config {
-    fn clone_into_box(&self) -> Box<Source + Send + Sync> {
+    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
         Box::new((*self).clone())
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -125,7 +125,7 @@ impl<'de> de::Deserializer<'de> for Value {
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_enum(EnumAccess{ value: self, name: name, variants: variants })
+        visitor.visit_enum(EnumAccess{ value: self, name, variants })
     }
 
     forward_to_deserialize_any! {
@@ -241,12 +241,12 @@ struct EnumAccess {
 }
 
 impl EnumAccess {
-    fn variant_deserializer(&self, name: &String) -> Result<StrDeserializer> {
+    fn variant_deserializer(&self, name: &str) -> Result<StrDeserializer> {
         self.variants
             .iter()
-            .find(|&s| s == name)
+            .find(|&s| s == &name)
             .map(|&s| StrDeserializer(s))
-            .ok_or(self.no_constructor_error(name))
+            .ok_or_else(|| self.no_constructor_error(name))
     }
 
     fn table_deserializer(&self, table: &Table) -> Result<StrDeserializer> {
@@ -448,7 +448,7 @@ impl<'de> de::Deserializer<'de> for Config {
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_enum(EnumAccess{ value: self.cache, name: name, variants: variants })
+        visitor.visit_enum(EnumAccess{ value: self.cache, name, variants })
     }
 
     forward_to_deserialize_any! {

--- a/src/env.rs
+++ b/src/env.rs
@@ -63,7 +63,7 @@ impl Default for Environment {
 }
 
 impl Source for Environment {
-    fn clone_into_box(&self) -> Box<Source + Send + Sync> {
+    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
         Box::new((*self).clone())
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,7 +51,7 @@ pub enum ConfigError {
 
         /// The captured error from attempting to parse the file in its desired format.
         /// This is the actual error object from the library used for the parsing.
-        cause: Box<Error + Send + Sync>,
+        cause: Box<dyn Error + Send + Sync>,
     },
 
     /// Value could not be converted into the requested type.
@@ -76,7 +76,7 @@ pub enum ConfigError {
     Message(String),
 
     /// Unadorned error from a foreign origin.
-    Foreign(Box<Error + Send + Sync>),
+    Foreign(Box<dyn Error + Send + Sync>),
 }
 
 impl ConfigError {
@@ -88,9 +88,9 @@ impl ConfigError {
         expected: &'static str,
     ) -> Self {
         ConfigError::Type {
-            origin: origin,
-            unexpected: unexpected,
-            expected: expected,
+            origin,
+            unexpected,
+            expected,
             key: None,
         }
     }
@@ -105,9 +105,9 @@ impl ConfigError {
                 expected,
                 ..
             } => ConfigError::Type {
-                origin: origin,
-                unexpected: unexpected,
-                expected: expected,
+                origin,
+                unexpected,
+                expected,
                 key: Some(key.into()),
             },
 
@@ -223,7 +223,7 @@ impl Error for ConfigError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             ConfigError::Foreign(ref cause) | ConfigError::FileParse { ref cause, .. } => {
                 Some(cause.as_ref())

--- a/src/file/format/hjson.rs
+++ b/src/file/format/hjson.rs
@@ -7,7 +7,7 @@ use value::{Value, ValueKind};
 pub fn parse(
     uri: Option<&String>,
     text: &str,
-) -> Result<HashMap<String, Value>, Box<Error + Send + Sync>> {
+) -> Result<HashMap<String, Value>, Box<dyn Error + Send + Sync>> {
     // Parse a JSON object value from the text
     // TODO: Have a proper error fire if the root of a file is ever not a Table
     let value = from_hjson_value(uri, &serde_hjson::from_str(text)?);

--- a/src/file/format/ini.rs
+++ b/src/file/format/ini.rs
@@ -7,7 +7,7 @@ use value::{Value, ValueKind};
 pub fn parse(
     uri: Option<&String>,
     text: &str,
-) -> Result<HashMap<String, Value>, Box<Error + Send + Sync>> {
+) -> Result<HashMap<String, Value>, Box<dyn Error + Send + Sync>> {
     let mut map: HashMap<String, Value> = HashMap::new();
     let i = Ini::load_from_str(text)?;
     for (sec, prop) in i.iter() {

--- a/src/file/format/json.rs
+++ b/src/file/format/json.rs
@@ -7,7 +7,7 @@ use value::{Value, ValueKind};
 pub fn parse(
     uri: Option<&String>,
     text: &str,
-) -> Result<HashMap<String, Value>, Box<Error + Send + Sync>> {
+) -> Result<HashMap<String, Value>, Box<dyn Error + Send + Sync>> {
     // Parse a JSON object value from the text
     // TODO: Have a proper error fire if the root of a file is ever not a Table
     let value = from_json_value(uri, &serde_json::from_str(text)?);

--- a/src/file/format/mod.rs
+++ b/src/file/format/mod.rs
@@ -72,22 +72,22 @@ lazy_static! {
 impl FileFormat {
     // TODO: pub(crate)
     #[doc(hidden)]
-    pub fn extensions(&self) -> &'static Vec<&'static str> {
+    pub fn extensions(self) -> &'static Vec<&'static str> {
         // It should not be possible for this to fail
         // A FileFormat would need to be declared without being added to the
         // ALL_EXTENSIONS map.
-        ALL_EXTENSIONS.get(self).unwrap()
+        ALL_EXTENSIONS.get(&self).unwrap()
     }
 
     // TODO: pub(crate)
     #[doc(hidden)]
     #[allow(unused_variables)]
     pub fn parse(
-        &self,
+        self,
         uri: Option<&String>,
         text: &str,
-    ) -> Result<HashMap<String, Value>, Box<Error + Send + Sync>> {
-        match *self {
+    ) -> Result<HashMap<String, Value>, Box<dyn Error + Send + Sync>> {
+        match self {
             #[cfg(feature = "toml")]
             FileFormat::Toml => toml::parse(uri, text),
 

--- a/src/file/format/toml.rs
+++ b/src/file/format/toml.rs
@@ -7,7 +7,7 @@ use value::{Value, ValueKind};
 pub fn parse(
     uri: Option<&String>,
     text: &str,
-) -> Result<HashMap<String, Value>, Box<Error + Send + Sync>> {
+) -> Result<HashMap<String, Value>, Box<dyn Error + Send + Sync>> {
     // Parse a TOML value from the provided text
     // TODO: Have a proper error fire if the root of a file is ever not a Table
     let value = from_toml_value(uri, &toml::from_str(text)?);

--- a/src/file/format/yaml.rs
+++ b/src/file/format/yaml.rs
@@ -9,7 +9,7 @@ use yaml_rust as yaml;
 pub fn parse(
     uri: Option<&String>,
     text: &str,
-) -> Result<HashMap<String, Value>, Box<Error + Send + Sync>> {
+) -> Result<HashMap<String, Value>, Box<dyn Error + Send + Sync>> {
     // Parse a YAML object from file
     let mut docs = yaml::YamlLoader::load_from_str(text)?;
     let root = match docs.len() {

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -94,7 +94,7 @@ where
     T: 'static,
     T: Sync + Send,
 {
-    fn clone_into_box(&self) -> Box<Source + Send + Sync> {
+    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
         Box::new((*self).clone())
     }
 
@@ -120,8 +120,8 @@ where
         format
             .parse(uri.as_ref(), &contents)
             .map_err(|cause| ConfigError::FileParse {
-                uri: uri,
-                cause: cause,
+                uri,
+                cause,
             })
     }
 }

--- a/src/file/source/file.rs
+++ b/src/file/source/file.rs
@@ -21,13 +21,13 @@ pub struct FileSourceFile {
 
 impl FileSourceFile {
     pub fn new(name: PathBuf) -> FileSourceFile {
-        FileSourceFile { name: name }
+        FileSourceFile { name }
     }
 
     fn find_file(
         &self,
         format_hint: Option<FileFormat>,
-    ) -> Result<(PathBuf, FileFormat), Box<Error + Send + Sync>> {
+    ) -> Result<(PathBuf, FileFormat), Box<dyn Error + Send + Sync>> {
         // First check for an _exact_ match
         let mut filename = env::current_dir()?.as_path().join(self.name.clone());
         if filename.is_file() {
@@ -91,7 +91,7 @@ impl FileSource for FileSourceFile {
     fn resolve(
         &self,
         format_hint: Option<FileFormat>,
-    ) -> Result<(Option<String>, String, FileFormat), Box<Error + Send + Sync>> {
+    ) -> Result<(Option<String>, String, FileFormat), Box<dyn Error + Send + Sync>> {
         // Find file
         let (filename, format) = self.find_file(format_hint)?;
 
@@ -103,7 +103,7 @@ impl FileSource for FileSourceFile {
         };
 
         // Read contents from file
-        let mut file = fs::File::open(filename.clone())?;
+        let mut file = fs::File::open(filename)?;
         let mut text = String::new();
         file.read_to_string(&mut text)?;
 

--- a/src/file/source/mod.rs
+++ b/src/file/source/mod.rs
@@ -12,5 +12,5 @@ pub trait FileSource: Debug + Clone {
     fn resolve(
         &self,
         format_hint: Option<FileFormat>,
-    ) -> Result<(Option<String>, String, FileFormat), Box<Error + Send + Sync>>;
+    ) -> Result<(Option<String>, String, FileFormat), Box<dyn Error + Send + Sync>>;
 }

--- a/src/file/source/string.rs
+++ b/src/file/source/string.rs
@@ -19,7 +19,7 @@ impl FileSource for FileSourceString {
     fn resolve(
         &self,
         format_hint: Option<FileFormat>,
-    ) -> Result<(Option<String>, String, FileFormat), Box<Error + Send + Sync>> {
+    ) -> Result<(Option<String>, String, FileFormat), Box<dyn Error + Send + Sync>> {
         Ok((
             None,
             self.0.clone(),

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -152,7 +152,6 @@ impl Expression {
             },
 
             Expression::Subscript(ref expr, index) => {
-                let mut do_again = false;
                 match expr.get_mut_forcibly(root) {
                     Some(value) => {
                         match value.kind {
@@ -244,20 +243,16 @@ impl Expression {
                         _ => *parent = Vec::<Value>::new().into(),
                     }
 
-                    match parent.kind {
-                        ValueKind::Array(ref mut array) => {
-                            let uindex = sindex_to_uindex(index, array.len());
-                            if uindex >= array.len() {
-                                array.resize(
-                                    (uindex + 1) as usize,
-                                    Value::new(None, ValueKind::Nil),
-                                );
-                            }
-
-                            array[uindex] = value.clone();
+                    if let ValueKind::Array(ref mut array) = parent.kind {
+                        let uindex = sindex_to_uindex(index, array.len());
+                        if uindex >= array.len() {
+                            array.resize(
+                                (uindex + 1) as usize,
+                                Value::new(None, ValueKind::Nil),
+                            );
                         }
 
-                        _ => (),
+                        array[uindex] = value;
                     }
                 }
             }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -48,7 +48,7 @@ impl ConfigSerializer {
             self.keys
                 .get_mut(len - 1)
                 .map(|pair| pair.1 = pair.1.map(|i| i + 1).or(Some(0)))
-                .ok_or(ConfigError::Message(format!(
+                .ok_or_else(|| ConfigError::Message(format!(
                     "last key is not found in {} keys",
                     len
                 )))

--- a/src/source.rs
+++ b/src/source.rs
@@ -7,7 +7,7 @@ use value::{Value, ValueKind};
 
 /// Describes a generic _source_ of configuration properties.
 pub trait Source: Debug {
-    fn clone_into_box(&self) -> Box<Source + Send + Sync>;
+    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync>;
 
     /// Collect all configuration properties available from this source and return
     /// a HashMap.
@@ -35,14 +35,14 @@ pub trait Source: Debug {
     }
 }
 
-impl Clone for Box<Source + Send + Sync> {
-    fn clone(&self) -> Box<Source + Send + Sync> {
+impl Clone for Box<dyn Source + Send + Sync> {
+    fn clone(&self) -> Box<dyn Source + Send + Sync> {
         self.clone_into_box()
     }
 }
 
-impl Source for Vec<Box<Source + Send + Sync>> {
-    fn clone_into_box(&self) -> Box<Source + Send + Sync> {
+impl Source for Vec<Box<dyn Source + Send + Sync>> {
+    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
         Box::new((*self).clone())
     }
 
@@ -67,7 +67,7 @@ where
     T: Clone,
     T: 'static,
 {
-    fn clone_into_box(&self) -> Box<Source + Send + Sync> {
+    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
         Box::new((*self).clone())
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -39,7 +39,7 @@ where
 
 impl From<String> for ValueKind {
     fn from(value: String) -> Self {
-        ValueKind::String(value.into())
+        ValueKind::String(value)
     }
 }
 
@@ -179,17 +179,17 @@ impl Value {
 
             // Unexpected type
             ValueKind::Nil => Err(ConfigError::invalid_type(
-                self.origin.clone(),
+                self.origin,
                 Unexpected::Unit,
                 "a boolean",
             )),
             ValueKind::Table(_) => Err(ConfigError::invalid_type(
-                self.origin.clone(),
+                self.origin,
                 Unexpected::Map,
                 "a boolean",
             )),
             ValueKind::Array(_) => Err(ConfigError::invalid_type(
-                self.origin.clone(),
+                self.origin,
                 Unexpected::Seq,
                 "a boolean",
             )),
@@ -234,7 +234,7 @@ impl Value {
                 "an integer",
             )),
             ValueKind::Array(_) => Err(ConfigError::invalid_type(
-                self.origin.clone(),
+                self.origin,
                 Unexpected::Seq,
                 "an integer",
             )),
@@ -269,17 +269,17 @@ impl Value {
 
             // Unexpected type
             ValueKind::Nil => Err(ConfigError::invalid_type(
-                self.origin.clone(),
+                self.origin,
                 Unexpected::Unit,
                 "a floating point",
             )),
             ValueKind::Table(_) => Err(ConfigError::invalid_type(
-                self.origin.clone(),
+                self.origin,
                 Unexpected::Map,
                 "a floating point",
             )),
             ValueKind::Array(_) => Err(ConfigError::invalid_type(
-                self.origin.clone(),
+                self.origin,
                 Unexpected::Seq,
                 "a floating point",
             )),
@@ -500,7 +500,7 @@ impl<'de> Deserialize<'de> for Value {
             {
                 let mut vec = Array::new();
 
-                while let Some(elem) = try!(visitor.next_element()) {
+                while let Some(elem) = visitor.next_element()? {
                     vec.push(elem);
                 }
 
@@ -513,7 +513,7 @@ impl<'de> Deserialize<'de> for Value {
             {
                 let mut values = Table::new();
 
-                while let Some((key, value)) = try!(visitor.next_entry()) {
+                while let Some((key, value)) = visitor.next_entry()? {
                     values.insert(key, value);
                 }
 


### PR DESCRIPTION
Apply clippy suggestions:
- Redundant field names in struct initialization
- Use of deprecated item 'try': use the `?` operator instead
- Trait objects without an explicit `dyn` are deprecated
- Unused variable
- Writing `&String` instead of `&str` involves a new object where a slice will do.
- Use of `ok_or` followed by a function call
- This argument (1 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
- Redundant clone
- You seem to be trying to use match for destructuring a single pattern. Consider using `if let`
- Identical conversion