### PR TITLE
Adding support for automatically injecting environment variables in configuration file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,17 +19,19 @@ json = ["serde_json"]
 yaml = ["yaml-rust"]
 hjson = ["serde-hjson"]
 ini = ["rust-ini"]
+with_env_vars = ["regex"]
 
 [dependencies]
 lazy_static = "1.0"
 serde = "1.0.8"
 nom = "5.0.0"
-
 toml = { version = "0.5", optional = true }
 serde_json = { version = "1.0.2", optional = true }
 yaml-rust = { version = "0.4", optional = true }
 serde-hjson = { version = "0.9", optional = true }
 rust-ini = { version = "0.13", optional = true }
+regex = {version="1",optional=true}
+
 
 [dev-dependencies]
 serde_derive = "1.0.8"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ config = "0.9"
 See the [documentation](https://docs.rs/config) or [examples](https://github.com/mehcode/config-rs/tree/master/examples) for
 more usage information.
 
+
+### Environment Variables Injection
+ - `with_env_vars` - adds support for environment variable injection into the configuration file. See [example](./examples/env_injection).
+
+
+
+
+
+
+
 ## License
 
 config-rs is primarily distributed under the terms of both the MIT license and the Apache License (Version 2.0).

--- a/examples/env_injection/Cargo.toml
+++ b/examples/env_injection/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "env_injection"
+version = "0.1.0"
+
+[dependencies]
+config = { path = "../../", features = ["with_env_vars"] }

--- a/examples/env_injection/Settings.toml
+++ b/examples/env_injection/Settings.toml
@@ -1,0 +1,3 @@
+debug = "${debug_env}"
+priority = "${priority_env}"
+key = "${key_env}"

--- a/examples/env_injection/src/main.rs
+++ b/examples/env_injection/src/main.rs
@@ -1,0 +1,24 @@
+extern crate config;
+use std::env;
+use std::collections::HashMap;
+
+fn main() {
+    env::set_var("debug_env","true");
+    env::set_var("priority_env","1");
+    env::set_var("key_env","sdjfdjkfjdkjfkj");
+
+    let mut settings = config::Config::default();
+    settings
+        // Add in `./Settings.toml`
+        .merge(config::File::with_name("Settings")).unwrap()
+        // Add in settings from the environment (with a prefix of APP)
+        // Eg.. `APP_DEBUG=1 ./target/app` would set the `debug` key
+        .merge(config::Environment::with_prefix("APP")).unwrap();
+
+    // Print out our settings (as a HashMap)
+    println!("{:?}",
+             settings.try_into::<HashMap<String, String>>().unwrap());
+    env::remove_var("debug_env");
+    env::remove_var("priority_env");
+    env::remove_var("key_env");
+}

--- a/tests/Settings-with-envs.ini
+++ b/tests/Settings-with-envs.ini
@@ -1,0 +1,9 @@
+debug = true
+production = false
+[place]
+name = ${famous_tower}
+longitude = 43.7224985
+latitude = 10.3970522
+favorite = false
+reviews = 3866
+rating = 4.5

--- a/tests/Settings-with-envs.json
+++ b/tests/Settings-with-envs.json
@@ -1,0 +1,16 @@
+{
+    "debug": true,
+    "production": false,
+    "arr": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    "place": {
+        "name": "${famous_tower}",
+        "longitude": 43.7224985,
+        "latitude": 10.3970522,
+        "favorite": false,
+        "reviews": 3866,
+        "rating": 4.5,
+        "creator": {
+            "name": "John Smith"
+        }
+    }
+}

--- a/tests/Settings-with-envs.toml
+++ b/tests/Settings-with-envs.toml
@@ -1,0 +1,53 @@
+debug = true
+debug_s = "true"
+production = false
+production_s = "false"
+
+code = 53
+
+# errors
+boolean_s_parse = "fals"
+
+arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+quarks = ["up", "down", "strange", "charm", "bottom", "top"]
+
+[diodes]
+green = "off"
+
+[diodes.red]
+brightness = 100
+
+[diodes.blue]
+blinking = [300, 700]
+
+[diodes.white.pattern]
+name = "christmas"
+inifinite = true
+
+[[items]]
+name = "1"
+
+[[items]]
+name = "2"
+
+[place]
+number = 1
+name = "${famous_tower}"
+longitude = 43.7224985
+latitude = 10.3970522
+favorite = false
+reviews = 3866
+rating = 4.5
+
+[place.creator]
+name = "John Smith"
+
+[proton]
+up = 2
+down = 1
+
+[divisors]
+1 = 1
+2 = 2
+4 = 3
+5 = 2

--- a/tests/Settings-with-envs.yaml
+++ b/tests/Settings-with-envs.yaml
@@ -1,0 +1,12 @@
+debug: true
+production: false
+arr: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+place:
+    name: ${famous_tower}
+    longitude: 43.7224985
+    latitude: 10.3970522
+    favorite: false
+    reviews: 3866
+    rating: 4.5
+    creator:
+        name: John Smith

--- a/tests/Settings-with-invalid-envs.ini
+++ b/tests/Settings-with-invalid-envs.ini
@@ -1,0 +1,9 @@
+debug = true
+production = false
+[place]
+name = ${famous&_tower}
+longitude = ${long==}
+latitude = ${lat++}
+favorite = ${bool!echo}
+reviews = 3866
+rating = 4.5

--- a/tests/Settings-with-invalid-envs.json
+++ b/tests/Settings-with-invalid-envs.json
@@ -1,0 +1,16 @@
+{
+    "debug": true,
+    "production": false,
+    "arr": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    "place": {
+        "name": "${famous&_tower}",
+        "longitude": "${long==}",
+        "latitude": "${lat++}",
+        "favorite": "${bool!echo}",
+        "reviews": 3866,
+        "rating": 4.5,
+        "creator": {
+            "name": "John Smith"
+        }
+    }
+}

--- a/tests/Settings-with-invalid-envs.toml
+++ b/tests/Settings-with-invalid-envs.toml
@@ -1,0 +1,53 @@
+debug = true
+debug_s = "true"
+production = false
+production_s = "false"
+
+code = 53
+
+# errors
+boolean_s_parse = "fals"
+
+arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+quarks = ["up", "down", "strange", "charm", "bottom", "top"]
+
+[diodes]
+green = "off"
+
+[diodes.red]
+brightness = 100
+
+[diodes.blue]
+blinking = [300, 700]
+
+[diodes.white.pattern]
+name = "christmas"
+inifinite = true
+
+[[items]]
+name = "1"
+
+[[items]]
+name = "2"
+
+[place]
+number = 1
+name = "${famous&_tower}"
+longitude = "${long==}"
+latitude = "${lat++}"
+favorite = "${bool!echo}"
+reviews = 3866
+rating = 4.5
+
+[place.creator]
+name = "John Smith"
+
+[proton]
+up = 2
+down = 1
+
+[divisors]
+1 = 1
+2 = 2
+4 = 3
+5 = 2

--- a/tests/Settings-with-invalid-envs.yaml
+++ b/tests/Settings-with-invalid-envs.yaml
@@ -1,0 +1,12 @@
+debug: true
+production: false
+arr: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+place:
+    name: ${famous&_tower}
+    longitude: ${long==}
+    latitude: ${lat++}
+    favorite: ${bool!echo}
+    reviews: 3866
+    rating: 4.5
+    creator:
+        name: John Smith

--- a/tests/file_ini.rs
+++ b/tests/file_ini.rs
@@ -63,3 +63,73 @@ fn test_error_parse() {
         r#"2:0 Expecting "[Some('='), Some(':')]" but found EOF. in tests/Settings-invalid.ini"#
     );
 }
+
+
+
+#[cfg(feature = "with_env_vars")]
+use std::env;
+use std::collections::HashMap;
+
+#[test]
+#[cfg(feature = "with_env_vars")]
+fn test_config_with_envs() {
+    env::set_var("famous_tower", "Torre di Pisa");
+    let mut c = Config::default();
+    c.merge(File::with_name("tests/Settings-with-envs"))
+        .unwrap();
+    let c  = c.collect().unwrap();
+    let k = c.get("debug").unwrap().clone();
+    assert_eq!(k.into_bool().ok(), Some(true));
+    let k = c.get("production").unwrap().clone();
+    assert_eq!(k.into_bool().ok(), Some(false));
+    let m: HashMap<String, Value> = c.get("place").unwrap().clone().into_table().unwrap();
+    assert_eq!(
+        m["name"].clone().into_str().unwrap(),
+        "Torre di Pisa".to_string()
+    );
+    env::remove_var("famous_tower");
+}
+
+
+
+
+#[test]
+#[cfg(feature = "with_env_vars")]
+fn test_config_with_invalid_envs() {
+    env::set_var("famous&_tower", "Torre di Pisa");
+    env::set_var("long", "Torre di Pisa");
+    env::set_var("lat++", "Torre di Pisa");
+    env::set_var("bool!echo", "Torre di Pisa");
+
+    let mut c = Config::default();
+    c.merge(File::with_name("tests/Settings-with-invalid-envs"))
+        .unwrap();
+    let c  = c.collect().unwrap();
+    let k = c.get("debug").unwrap().clone();
+    assert_eq!(k.into_bool().ok(), Some(true));
+    let k = c.get("production").unwrap().clone();
+    assert_eq!(k.into_bool().ok(), Some(false));
+    let m: HashMap<String, Value> = c.get("place").unwrap().clone().into_table().unwrap();
+    assert_eq!(
+        m["name"].clone().into_str().unwrap(),
+        "${famous&_tower}".to_string()
+    );
+    assert_eq!(
+        m["longitude"].clone().into_str().unwrap(),
+        "${long==}".to_string()
+    );
+    assert_eq!(
+        m["latitude"].clone().into_str().unwrap(),
+        "${lat++}".to_string()
+    );
+
+    assert_eq!(
+        m["favorite"].clone().into_str().unwrap(),
+        "${bool!echo}".to_string()
+    );
+
+    env::remove_var("famous&_tower");
+    env::remove_var("long");
+    env::remove_var("lat++");
+    env::remove_var("bool!echo");
+}

--- a/tests/file_json.rs
+++ b/tests/file_json.rs
@@ -75,3 +75,72 @@ fn test_error_parse() {
         "expected `:` at line 4 column 1 in tests/Settings-invalid.json".to_string()
     );
 }
+
+
+#[cfg(feature = "with_env_vars")]
+use std::env;
+
+
+#[test]
+#[cfg(feature = "with_env_vars")]
+fn test_config_with_envs() {
+    env::set_var("famous_tower", "Torre di Pisa");
+    let mut c = Config::default();
+    c.merge(File::with_name("tests/Settings-with-envs"))
+        .unwrap();
+    let c  = c.collect().unwrap();
+    let k = c.get("debug").unwrap().clone();
+    assert_eq!(k.into_bool().ok(), Some(true));
+    let k = c.get("production").unwrap().clone();
+    assert_eq!(k.into_bool().ok(), Some(false));
+    let m: HashMap<String, Value> = c.get("place").unwrap().clone().into_table().unwrap();
+    assert_eq!(
+        m["name"].clone().into_str().unwrap(),
+        "Torre di Pisa".to_string()
+    );
+    env::remove_var("famous_tower");
+}
+
+
+
+
+#[test]
+#[cfg(feature = "with_env_vars")]
+fn test_config_with_invalid_envs() {
+    env::set_var("famous&_tower", "Torre di Pisa");
+    env::set_var("long", "Torre di Pisa");
+    env::set_var("lat++", "Torre di Pisa");
+    env::set_var("bool!echo", "Torre di Pisa");
+
+    let mut c = Config::default();
+    c.merge(File::with_name("tests/Settings-with-invalid-envs"))
+        .unwrap();
+    let c  = c.collect().unwrap();
+    let k = c.get("debug").unwrap().clone();
+    assert_eq!(k.into_bool().ok(), Some(true));
+    let k = c.get("production").unwrap().clone();
+    assert_eq!(k.into_bool().ok(), Some(false));
+    let m: HashMap<String, Value> = c.get("place").unwrap().clone().into_table().unwrap();
+    assert_eq!(
+        m["name"].clone().into_str().unwrap(),
+        "${famous&_tower}".to_string()
+    );
+    assert_eq!(
+        m["longitude"].clone().into_str().unwrap(),
+        "${long==}".to_string()
+    );
+    assert_eq!(
+        m["latitude"].clone().into_str().unwrap(),
+        "${lat++}".to_string()
+    );
+
+    assert_eq!(
+        m["favorite"].clone().into_str().unwrap(),
+        "${bool!echo}".to_string()
+    );
+
+    env::remove_var("famous&_tower");
+    env::remove_var("long");
+    env::remove_var("lat++");
+    env::remove_var("bool!echo");
+}

--- a/tests/file_toml.rs
+++ b/tests/file_toml.rs
@@ -85,3 +85,73 @@ fn test_error_parse() {
         "failed to parse datetime for key `error` at line 2 column 9 in tests/Settings-invalid.toml".to_string()
     );
 }
+
+
+#[cfg(feature = "with_env_vars")]
+use std::env;
+
+
+#[test]
+#[cfg(feature = "with_env_vars")]
+fn test_config_with_envs() {
+    env::set_var("famous_tower", "Torre di Pisa");
+    let mut c = Config::default();
+    c.merge(File::with_name("tests/Settings-with-envs"))
+        .unwrap();
+    let c  = c.collect().unwrap();
+    let k = c.get("debug").unwrap().clone();
+    assert_eq!(k.into_bool().ok(), Some(true));
+    let k = c.get("production").unwrap().clone();
+    assert_eq!(k.into_bool().ok(), Some(false));
+    let m: HashMap<String, Value> = c.get("place").unwrap().clone().into_table().unwrap();
+    assert_eq!(
+        m["name"].clone().into_str().unwrap(),
+        "Torre di Pisa".to_string()
+    );
+    env::remove_var("famous_tower");
+}
+
+
+
+
+#[test]
+#[cfg(feature = "with_env_vars")]
+fn test_config_with_invalid_envs() {
+    env::set_var("famous&_tower", "Torre di Pisa");
+    env::set_var("long", "Torre di Pisa");
+    env::set_var("lat++", "Torre di Pisa");
+    env::set_var("bool!echo", "Torre di Pisa");
+
+    let mut c = Config::default();
+    c.merge(File::with_name("tests/Settings-with-invalid-envs"))
+        .unwrap();
+    let c  = c.collect().unwrap();
+    let k = c.get("debug").unwrap().clone();
+    assert_eq!(k.into_bool().ok(), Some(true));
+    let k = c.get("production").unwrap().clone();
+    assert_eq!(k.into_bool().ok(), Some(false));
+    let m: HashMap<String, Value> = c.get("place").unwrap().clone().into_table().unwrap();
+    assert_eq!(
+        m["name"].clone().into_str().unwrap(),
+        "${famous&_tower}".to_string()
+    );
+    assert_eq!(
+        m["longitude"].clone().into_str().unwrap(),
+        "${long==}".to_string()
+    );
+    assert_eq!(
+        m["latitude"].clone().into_str().unwrap(),
+        "${lat++}".to_string()
+    );
+
+    assert_eq!(
+        m["favorite"].clone().into_str().unwrap(),
+        "${bool!echo}".to_string()
+    );
+
+    env::remove_var("famous&_tower");
+    env::remove_var("long");
+    env::remove_var("lat++");
+    env::remove_var("bool!echo");
+}
+


### PR DESCRIPTION
Rationale;

Creating a different configuration file for different deployments could be tedious especially in cloud environment and we could end up with many different configuration files. It could be potentially easier to set environment variables and inject those into placeholders in the configuration file. 
The approach is similar to Spring application.properties where environment variables are automatically resolved and injected on deployment. 

This should tie in well with Docker and Kubernetes which make it easy to pass variables into containers.



