### PR TITLE
Introduce an option for disabling the automatic resolver in FileSourceFile

### DIFF
--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -55,6 +55,20 @@ impl File<source::file::FileSourceFile> {
             source: source::file::FileSourceFile::new(name.into()),
         }
     }
+
+    /// Given the full name of a file, will use it only if with the exact name without
+    /// any attempt to locate another file. It will analyze the extension if the property
+    /// format isn't setted but without using file with a different fullname.
+    pub fn with_exact_name(name: &str) -> Self {
+        Self::with_name(name).exact_name(true)
+    }
+
+    /// If enabeld, if a file with the exact name is not found,
+    /// will not attempt to locate a file based on the format property.
+    pub fn exact_name(mut self, flag: bool) -> Self {
+        self.source.disable_file_resolve(flag);
+        self
+    }
 }
 
 impl<'a> From<&'a Path> for File<source::file::FileSourceFile> {

--- a/src/file/source/file.rs
+++ b/src/file/source/file.rs
@@ -50,7 +50,7 @@ impl FileSourceFile {
                         io::ErrorKind::NotFound,
                         format!(
                             "configuration file \"{}\" is not of a registered file format",
-                            filename.to_string_lossy()
+                            self.name.to_string_lossy()
                         ),
                     )))
                 }

--- a/tests/Settings.wrongextension
+++ b/tests/Settings.wrongextension
@@ -1,0 +1,8 @@
+debug = false
+production = true
+
+[place]
+rating = 4.9
+
+[place.creator]
+name = "Somebody New"

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -25,6 +25,40 @@ fn test_file_required_not_found() {
 }
 
 #[test]
+fn test_file_exact_not_exist() {
+    let mut c = Config::default();
+    let res = c.merge(File::with_exact_name("tests/Settings.wrong"));
+
+    assert!(res.is_err());
+    assert_eq!(
+        res.unwrap_err().to_string(),
+        "configuration file \"tests/Settings.wrong\" not found".to_string()
+    );
+}
+
+#[test]
+fn test_file_exact_exist_invalid_extension() {
+    let mut c = Config::default();
+    let res = c.merge(File::with_exact_name("tests/Settings.wrongextension"));
+
+    assert!(res.is_err());
+    assert_eq!(
+        res.unwrap_err().to_string(),
+        "configuration file \"tests/Settings.wrongextension\" is not of a registered file format".to_string()
+    );
+}
+
+#[test]
+fn test_file_exact_explicit_format() {
+    let mut c = Config::default();
+    c.merge(File::new("tests/Settings.wrongextension", FileFormat::Toml).exact_name(true))
+        .unwrap();
+
+    assert_eq!(c.get("debug").ok(), Some(false));
+    assert_eq!(c.get("production").ok(), Some(true));
+}
+
+#[test]
 fn test_file_auto() {
     let mut c = Config::default();
     c.merge(File::with_name("tests/Settings-production"))


### PR DESCRIPTION
A new feature with granted retro compatibility.
To solve the problem introduced in https://github.com/mehcode/config-rs/issues/132 I have introduced the solution number 3:

> Add a flag to the `FileSourceFile` struct named `use_resolver` and add a method in `File<FileSourceFile>` similar to `required(bool)` where the user can enable or disable the resolver in `FileSourceFile` (The best solution. No breaking change, no removing of feature, only adding an option flag that if not used will be set to `True` for retro compatibility)

The struct File now has two new methods, `with_exact_name` and `exact_name`, the first to create a File with a FileSourceFile imposed to not search the extension of the file.
With this approach, one can load a file named `Settings.wrongextension` as a Toml file like before, but if the file is missing the program will not search another file named for example `Settings.yaml` without asking.

I've introduced three tests for the new methods, and a very small fix of the wrong extension error message, because before it used the absolute path when the not found error used the relative/given path.