### PR TITLE
Fix paths in tests expectations for all platforms

### DIFF
--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -26,7 +26,7 @@ fn test_error_parse() {
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        format!("failed to parse datetime for key `error` at line 2 column 9 in {}", path.to_str().unwrap())
+        format!("failed to parse datetime for key `error` at line 2 column 9 in {}", path.display())
     );
 }
 
@@ -41,7 +41,7 @@ fn test_error_type() {
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        format!("invalid type: string \"fals\", expected a boolean for key `boolean_s_parse` in {}", path.to_str().unwrap())
+        format!("invalid type: string \"fals\", expected a boolean for key `boolean_s_parse` in {}", path.display())
     );
 }
 

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -6,6 +6,7 @@ extern crate config;
 extern crate serde_derive;
 
 use config::*;
+use std::path::PathBuf;
 
 fn make() -> Config {
     let mut c = Config::default();
@@ -20,10 +21,12 @@ fn test_error_parse() {
     let mut c = Config::default();
     let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Toml));
 
+    let path : PathBuf = ["tests", "Settings-invalid.toml"].iter().collect();
+
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        "failed to parse datetime for key `error` at line 2 column 9 in tests/Settings-invalid.toml".to_string()
+        format!("failed to parse datetime for key `error` at line 2 column 9 in {}", path.to_str().unwrap())
     );
 }
 
@@ -33,12 +36,12 @@ fn test_error_type() {
 
     let res = c.get::<bool>("boolean_s_parse");
 
+    let path : PathBuf = ["tests", "Settings.toml"].iter().collect();
+
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        "invalid type: string \"fals\", expected a boolean for key \
-         `boolean_s_parse` in tests/Settings.toml"
-            .to_string()
+        format!("invalid type: string \"fals\", expected a boolean for key `boolean_s_parse` in {}", path.to_str().unwrap())
     );
 }
 

--- a/tests/file_hjson.rs
+++ b/tests/file_hjson.rs
@@ -10,6 +10,7 @@ extern crate serde_derive;
 use config::*;
 use float_cmp::ApproxEqUlps;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 struct Place {
@@ -69,9 +70,11 @@ fn test_error_parse() {
     let mut c = Config::default();
     let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Hjson));
 
+    let path : PathBuf = ["tests", "Settings-invalid.hjson"].iter().collect();
+
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        "Found a punctuator where a key name was expected (check your syntax or use quotes if the key name includes {}[],: or whitespace) at line 4 column 1 in tests/Settings-invalid.hjson".to_string()
+        format!("Found a punctuator where a key name was expected (check your syntax or use quotes if the key name includes {{}}[],: or whitespace) at line 4 column 1 in {}", path.to_str().unwrap())
     );
 }

--- a/tests/file_hjson.rs
+++ b/tests/file_hjson.rs
@@ -75,6 +75,6 @@ fn test_error_parse() {
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        format!("Found a punctuator where a key name was expected (check your syntax or use quotes if the key name includes {{}}[],: or whitespace) at line 4 column 1 in {}", path.to_str().unwrap())
+        format!("Found a punctuator where a key name was expected (check your syntax or use quotes if the key name includes {{}}[],: or whitespace) at line 4 column 1 in {}", path.display())
     );
 }

--- a/tests/file_ini.rs
+++ b/tests/file_ini.rs
@@ -8,6 +8,7 @@ extern crate serde;
 extern crate serde_derive;
 
 use config::*;
+use std::path::PathBuf;
 
 #[derive(Debug, Deserialize, PartialEq)]
 struct Place {
@@ -57,9 +58,11 @@ fn test_error_parse() {
     let mut c = Config::default();
     let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Ini));
 
+    let path : PathBuf = ["tests", "Settings-invalid.ini"].iter().collect();
+
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        r#"2:0 Expecting "[Some('='), Some(':')]" but found EOF. in tests/Settings-invalid.ini"#
+        format!(r#"2:0 Expecting "[Some('='), Some(':')]" but found EOF. in {}"#, path.to_str().unwrap())
     );
 }

--- a/tests/file_ini.rs
+++ b/tests/file_ini.rs
@@ -63,6 +63,6 @@ fn test_error_parse() {
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        format!(r#"2:0 Expecting "[Some('='), Some(':')]" but found EOF. in {}"#, path.to_str().unwrap())
+        format!(r#"2:0 Expecting "[Some('='), Some(':')]" but found EOF. in {}"#, path.display())
     );
 }

--- a/tests/file_json.rs
+++ b/tests/file_json.rs
@@ -75,6 +75,6 @@ fn test_error_parse() {
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        format!("expected `:` at line 4 column 1 in {}", path_with_extension.to_str().unwrap())
+        format!("expected `:` at line 4 column 1 in {}", path_with_extension.display())
     );
 }

--- a/tests/file_json.rs
+++ b/tests/file_json.rs
@@ -10,6 +10,7 @@ extern crate serde_derive;
 use config::*;
 use float_cmp::ApproxEqUlps;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 struct Place {
@@ -69,9 +70,11 @@ fn test_error_parse() {
     let mut c = Config::default();
     let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Json));
 
+    let path_with_extension : PathBuf = ["tests", "Settings-invalid.json"].iter().collect();
+
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        "expected `:` at line 4 column 1 in tests/Settings-invalid.json".to_string()
+        format!("expected `:` at line 4 column 1 in {}", path_with_extension.to_str().unwrap())
     );
 }

--- a/tests/file_toml.rs
+++ b/tests/file_toml.rs
@@ -10,6 +10,7 @@ extern crate serde_derive;
 use config::*;
 use float_cmp::ApproxEqUlps;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 struct Place {
@@ -79,9 +80,11 @@ fn test_error_parse() {
     let mut c = Config::default();
     let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Toml));
 
+    let path_with_extension : PathBuf = ["tests", "Settings-invalid.toml"].iter().collect();
+
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        "failed to parse datetime for key `error` at line 2 column 9 in tests/Settings-invalid.toml".to_string()
+        format!("failed to parse datetime for key `error` at line 2 column 9 in {}", path_with_extension.to_str().unwrap())
     );
 }

--- a/tests/file_toml.rs
+++ b/tests/file_toml.rs
@@ -85,6 +85,6 @@ fn test_error_parse() {
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        format!("failed to parse datetime for key `error` at line 2 column 9 in {}", path_with_extension.to_str().unwrap())
+        format!("failed to parse datetime for key `error` at line 2 column 9 in {}", path_with_extension.display())
     );
 }

--- a/tests/file_yaml.rs
+++ b/tests/file_yaml.rs
@@ -76,6 +76,6 @@ fn test_error_parse() {
     assert_eq!(
         res.unwrap_err().to_string(),
         format!("while parsing a block mapping, did not find expected key at \
-         line 2 column 1 in {}", path_with_extension.to_str().unwrap())
+         line 2 column 1 in {}", path_with_extension.display())
     );
 }

--- a/tests/file_yaml.rs
+++ b/tests/file_yaml.rs
@@ -10,6 +10,7 @@ extern crate serde_derive;
 use config::*;
 use float_cmp::ApproxEqUlps;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 struct Place {
@@ -69,11 +70,12 @@ fn test_error_parse() {
     let mut c = Config::default();
     let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Yaml));
 
+    let path_with_extension : PathBuf = ["tests", "Settings-invalid.yaml"].iter().collect();
+
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        "while parsing a block mapping, did not find expected key at \
-         line 2 column 1 in tests/Settings-invalid.yaml"
-            .to_string()
+        format!("while parsing a block mapping, did not find expected key at \
+         line 2 column 1 in {}", path_with_extension.to_str().unwrap())
     );
 }


### PR DESCRIPTION
This is first thing I came across while trying to do some changes in code. I started tests and they failed due to different way paths are structured on Linux and on Windows, which is my development platform.

Here I did some changes so that expectations should work correctly on all the platforms.