### PR TITLE
port to rust-ini 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ toml = { version = "0.5", optional = true }
 serde_json = { version = "1.0.2", optional = true }
 yaml-rust = { version = "0.4", optional = true }
 serde-hjson = { version = "0.9", default-features = false, optional = true }
-rust-ini = { version = "0.13", optional = true }
+rust-ini = { version = "0.16", optional = true }
 
 [dev-dependencies]
 serde_derive = "1.0.8"

--- a/src/file/format/ini.rs
+++ b/src/file/format/ini.rs
@@ -11,17 +11,23 @@ pub fn parse(
     let mut map: HashMap<String, Value> = HashMap::new();
     let i = Ini::load_from_str(text)?;
     for (sec, prop) in i.iter() {
-        match *sec {
-            Some(ref sec) => {
+        match sec {
+            Some(sec) => {
                 let mut sec_map: HashMap<String, Value> = HashMap::new();
                 for (k, v) in prop.iter() {
-                    sec_map.insert(k.clone(), Value::new(uri, ValueKind::String(v.clone())));
+                    sec_map.insert(
+                        k.to_owned(),
+                        Value::new(uri, ValueKind::String(v.to_owned())),
+                    );
                 }
-                map.insert(sec.clone(), Value::new(uri, ValueKind::Table(sec_map)));
+                map.insert(sec.to_owned(), Value::new(uri, ValueKind::Table(sec_map)));
             }
             None => {
                 for (k, v) in prop.iter() {
-                    map.insert(k.clone(), Value::new(uri, ValueKind::String(v.clone())));
+                    map.insert(
+                        k.to_owned(),
+                        Value::new(uri, ValueKind::String(v.to_owned())),
+                    );
                 }
             }
         }

--- a/tests/file_ini.rs
+++ b/tests/file_ini.rs
@@ -64,7 +64,7 @@ fn test_error_parse() {
     assert_eq!(
         res.unwrap_err().to_string(),
         format!(
-            r#"2:0 Expecting "[Some('='), Some(':')]" but found EOF. in {}"#,
+            r#"2:0 expecting "[Some('='), Some(':')]" but found EOF. in {}"#,
             path.display()
         )
     );


### PR DESCRIPTION
- iterating over a loaded ini file sections / properties yields `str`s now, not Strings, so use `to_owned()`, not `clone()` to get an owned value from them
- adapt one test for a small change in an expected error message