### PR TITLE
Add Config::with_merged()

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -78,6 +78,28 @@ impl Config {
         self.refresh()
     }
 
+    /// Merge in a configuration property source.
+    pub fn with_merged<T>(mut self, source: T) -> Result<Self>
+    where
+        T: 'static,
+        T: Source + Send + Sync,
+    {
+        match self.kind {
+            ConfigKind::Mutable {
+                ref mut sources, ..
+            } => {
+                sources.push(Box::new(source));
+            }
+
+            ConfigKind::Frozen => {
+                return Err(ConfigError::Frozen);
+            }
+        }
+
+        self.refresh()?;
+        Ok(self)
+    }
+
     /// Refresh the configuration cache with fresh
     /// data from added sources.
     ///


### PR DESCRIPTION
This patch adds a builder-pattern version of Config::merge(), which can
be used for method-chain-building Config objects.
