### PR TITLE
Fix test failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ nom = "5.0.0"
 toml = { version = "0.5", optional = true }
 serde_json = { version = "1.0.2", optional = true }
 yaml-rust = { version = "0.4", optional = true }
-serde-hjson = { version = "0.9", optional = true }
+serde-hjson = { version = "0.9", default-features = false, optional = true }
 rust-ini = { version = "0.13", optional = true }
 
 [dev-dependencies]

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -27,7 +27,7 @@ fn test_error_parse() {
     assert_eq!(
         res.unwrap_err().to_string(),
         format!(
-            "failed to parse datetime for key `error` at line 2 column 9 in {}",
+            "invalid TOML value, did you mean to use a quoted string? at line 2 column 9 in {}",
             path.display()
         )
     );

--- a/tests/file_toml.rs
+++ b/tests/file_toml.rs
@@ -86,7 +86,7 @@ fn test_error_parse() {
     assert_eq!(
         res.unwrap_err().to_string(),
         format!(
-            "failed to parse datetime for key `error` at line 2 column 9 in {}",
+            "invalid TOML value, did you mean to use a quoted string? at line 2 column 9 in {}",
             path_with_extension.display()
         )
     );


### PR DESCRIPTION
As reported in

    https://github.com/hjson/hjson-rust/issues/23

the issue of the failing tests is the serde_hjson crate. The problem can
be prevented (as reported by
https://github.com/hjson/hjson-rust/issues/23#issuecomment-775520018) by
disabling the default features of the crate (namingly preservation of
key order).

This commit disables the default features of serde_hjson to fix our
tests.

--


Closes #158 