### PR TITLE
Add setter for setting config value once

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -151,6 +151,18 @@ impl Config {
         self.refresh()
     }
 
+    pub fn set_once(&mut self, key: &str, value: Value) -> Result<()> {
+        let expr: path::Expression = key.parse()?;
+
+        // Traverse the cache using the path to (possibly) retrieve a value
+        if let Some(ref mut val) = expr.get_mut(&mut self.cache) {
+            **val = value;
+        } else {
+            expr.set(&mut self.cache, value);
+        }
+        Ok(())
+    }
+
     pub fn get<'de, T: Deserialize<'de>>(&self, key: &str) -> Result<T> {
         // Parse the key into a path expression
         let expr: path::Expression = key.parse()?;


### PR DESCRIPTION
This PR supersedes #165 .

I was able to implement the functionality I've described in #163 using this function (fixup of relative pathes during loading of configuration data) with this PR.

The advantage of this PR over #165 is that this PR does not need to export internal types, thus it is better than #165.