### PR TITLE
Make function only available in tests

### DIFF
--- a/tests/file_toml.rs
+++ b/tests/file_toml.rs
@@ -41,6 +41,7 @@ struct Settings {
     elements: Vec<String>,
 }
 
+#[cfg(test)]
 fn make() -> Config {
     let mut c = Config::default();
     c.merge(File::new("tests/Settings", FileFormat::Toml))


### PR DESCRIPTION
This function is only used in tests, so make it only available there.

(Just a code cleanup change)