### PR TITLE
ConfigBuilder (was: Add Config::with_sources())

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -337,7 +337,7 @@ impl ConfigBuilder {
                 ref mut sources, ..
             } => {
                 sources.append(&mut self.sources);
-            },
+            }
 
             ConfigKind::Frozen => return Err(ConfigError::Frozen),
         }


### PR DESCRIPTION
This patch adds Config::with_sources() for builder-pattern multi-merge
without calling Config::refresh().
The documentation added in the patch serves as rationale.


---

I'd love to see discussion on this.