### PR TITLE
Documentation for `Config::set*()`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -156,6 +156,14 @@ impl Config {
         self.refresh()
     }
 
+    /// Set an overwrite
+    ///
+    /// This function sets an overwrite value.
+    /// The overwrite `value` is written to the `key` location on every `refresh()`
+    ///
+    /// # Warning
+    ///
+    /// Errors if config is frozen
     pub fn set<T>(&mut self, key: &str, value: T) -> Result<&mut Config>
     where
         T: Into<Value>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -139,6 +139,7 @@ impl Config {
         Ok(self)
     }
 
+    /// Set a default `value` at `key`
     pub fn set_default<T>(&mut self, key: &str, value: T) -> Result<&mut Config>
     where
         T: Into<Value>,


### PR DESCRIPTION
Closes #171 

Changing the interface is more destructive, thus I'd only add documentation on this.