### PR TITLE
Remove rustfmt on github-actions for nightly channel

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -60,7 +60,6 @@ jobs:
         rust:
           - stable
           - beta
-          - nightly
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
This is necessary because rustfmt seems to be unavailable on nightly
from time to time.
So we remove it here, so that our CI does not fail because of that.

Beta and stable channel rustfmt continues to be checked, though.