### PR TITLE
Rename get_str() → get_string() to match returned type

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -211,8 +211,8 @@ impl Config {
         }
     }
 
-    pub fn get_str(&self, key: &str) -> Result<String> {
-        self.get(key).and_then(Value::into_str)
+    pub fn get_string(&self, key: &str) -> Result<String> {
+        self.get(key).and_then(Value::into_string)
     }
 
     pub fn get_int(&self, key: &str) -> Result<i64> {

--- a/src/de.rs
+++ b/src/de.rs
@@ -89,12 +89,12 @@ impl<'de> de::Deserializer<'de> for Value {
 
     #[inline]
     fn deserialize_str<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visitor.visit_string(self.into_str()?)
+        visitor.visit_string(self.into_string()?)
     }
 
     #[inline]
     fn deserialize_string<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visitor.visit_string(self.into_str()?)
+        visitor.visit_string(self.into_string()?)
     }
 
     #[inline]
@@ -421,12 +421,12 @@ impl<'de> de::Deserializer<'de> for Config {
 
     #[inline]
     fn deserialize_str<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visitor.visit_string(self.cache.into_str()?)
+        visitor.visit_string(self.cache.into_string()?)
     }
 
     #[inline]
     fn deserialize_string<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visitor.visit_string(self.cache.into_str()?)
+        visitor.visit_string(self.cache.into_string()?)
     }
 
     #[inline]

--- a/src/value.rs
+++ b/src/value.rs
@@ -286,9 +286,9 @@ impl Value {
         }
     }
 
-    /// Returns `self` into a str, if possible.
+    /// Returns `self` into a string, if possible.
     // FIXME: Should this not be `try_into_*` ?
-    pub fn into_str(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String> {
         match self.kind {
             ValueKind::String(value) => Ok(value),
 

--- a/tests/file_hjson.rs
+++ b/tests/file_hjson.rs
@@ -60,7 +60,7 @@ fn test_file() {
     assert_eq!(s.elements.len(), 10);
     assert_eq!(s.elements[3], "4".to_string());
     assert_eq!(
-        s.place.creator["name"].clone().into_str().unwrap(),
+        s.place.creator["name"].clone().into_string().unwrap(),
         "John Smith".to_string()
     );
 }

--- a/tests/file_json.rs
+++ b/tests/file_json.rs
@@ -60,7 +60,7 @@ fn test_file() {
     assert_eq!(s.elements.len(), 10);
     assert_eq!(s.elements[3], "4".to_string());
     assert_eq!(
-        s.place.creator["name"].clone().into_str().unwrap(),
+        s.place.creator["name"].clone().into_string().unwrap(),
         "John Smith".to_string()
     );
 }
@@ -98,7 +98,7 @@ fn test_json_vec() {
 
     let v = c.get_array("WASTE").unwrap();
     let mut vi = v.into_iter();
-    assert_eq!(vi.next().unwrap().into_str().unwrap(), "example_dir1");
-    assert_eq!(vi.next().unwrap().into_str().unwrap(), "example_dir2");
+    assert_eq!(vi.next().unwrap().into_string().unwrap(), "example_dir1");
+    assert_eq!(vi.next().unwrap().into_string().unwrap(), "example_dir2");
     assert!(vi.next().is_none());
 }

--- a/tests/file_toml.rs
+++ b/tests/file_toml.rs
@@ -71,7 +71,7 @@ fn test_file() {
     assert_eq!(s.elements.len(), 10);
     assert_eq!(s.elements[3], "4".to_string());
     assert_eq!(
-        s.place.creator["name"].clone().into_str().unwrap(),
+        s.place.creator["name"].clone().into_string().unwrap(),
         "John Smith".to_string()
     );
 }

--- a/tests/file_yaml.rs
+++ b/tests/file_yaml.rs
@@ -60,7 +60,7 @@ fn test_file() {
     assert_eq!(s.elements.len(), 10);
     assert_eq!(s.elements[3], "4".to_string());
     assert_eq!(
-        s.place.creator["name"].clone().into_str().unwrap(),
+        s.place.creator["name"].clone().into_string().unwrap(),
         "John Smith".to_string()
     );
 }

--- a/tests/get.rs
+++ b/tests/get.rs
@@ -111,7 +111,7 @@ fn test_map() {
 
     assert_eq!(m.len(), 8);
     assert_eq!(
-        m["name"].clone().into_str().unwrap(),
+        m["name"].clone().into_string().unwrap(),
         "Torre di Pisa".to_string()
     );
     assert_eq!(m["reviews"].clone().into_int().unwrap(), 3866);
@@ -138,7 +138,7 @@ fn test_map_struct() {
 
     assert_eq!(s.place.len(), 8);
     assert_eq!(
-        s.place["name"].clone().into_str().unwrap(),
+        s.place["name"].clone().into_string().unwrap(),
         "Torre di Pisa".to_string()
     );
     assert_eq!(s.place["reviews"].clone().into_int().unwrap(), 3866);


### PR DESCRIPTION
Closes #140.

I couldn't find any good reason to make this return `&str` instead, the handling everywhere else is as `String` so just renaming the function to match what it already does seemed most logical thing to do.

This will be a breaking change to the API, but the fix will be easy. All instances of `Config.get_str()` need to be changed to `Config.get_string()`. The returned value being handled in people's code is already `String`.
