### PR TITLE
Remove dead code

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,36 +12,14 @@ use source::Source;
 use path;
 use value::{Table, Value, ValueKind};
 
-#[derive(Clone, Debug)]
-enum ConfigKind {
-    // A mutable configuration. This is the default.
-    Mutable {
-        defaults: HashMap<path::Expression, Value>,
-        overrides: HashMap<path::Expression, Value>,
-        sources: Vec<Box<dyn Source + Send + Sync>>,
-    },
-
-    // A frozen configuration.
-    // Configuration can no longer be mutated.
-    Frozen,
-}
-
-impl Default for ConfigKind {
-    fn default() -> Self {
-        ConfigKind::Mutable {
-            defaults: HashMap::new(),
-            overrides: HashMap::new(),
-            sources: Vec::new(),
-        }
-    }
-}
-
 /// A prioritized configuration repository. It maintains a set of
 /// configuration sources, fetches values to populate those, and provides
 /// them according to the source's priority.
 #[derive(Clone, Debug)]
 pub struct Config {
-    kind: ConfigKind,
+    defaults: HashMap<path::Expression, Value>,
+    overrides: HashMap<path::Expression, Value>,
+    sources: Vec<Box<dyn Source + Send + Sync>>,
 
     /// Root of the cached configuration.
     pub cache: Value,
@@ -50,35 +28,22 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            kind: ConfigKind::default(),
+            defaults: Default::default(),
+            overrides: Default::default(),
+            sources: Default::default(),
             cache: Value::new(None, Table::new()),
         }
     }
 }
 
 impl Config {
-    pub fn freeze(&mut self) {
-        self.kind = ConfigKind::Frozen
-    }
-
     /// Merge in a configuration property source.
     pub fn merge<T>(&mut self, source: T) -> Result<&mut Config>
     where
         T: 'static,
         T: Source + Send + Sync,
     {
-        match self.kind {
-            ConfigKind::Mutable {
-                ref mut sources, ..
-            } => {
-                sources.push(Box::new(source));
-            }
-
-            ConfigKind::Frozen => {
-                return Err(ConfigError::Frozen);
-            }
-        }
-
+        self.sources.push(Box::new(source));
         self.refresh()
     }
 
@@ -88,18 +53,7 @@ impl Config {
         T: 'static,
         T: Source + Send + Sync,
     {
-        match self.kind {
-            ConfigKind::Mutable {
-                ref mut sources, ..
-            } => {
-                sources.push(Box::new(source));
-            }
-
-            ConfigKind::Frozen => {
-                return Err(ConfigError::Frozen);
-            }
-        }
-
+        self.sources.push(Box::new(source));
         self.refresh()?;
         Ok(self)
     }
@@ -110,34 +64,23 @@ impl Config {
     /// Configuration is automatically refreshed after a mutation
     /// operation (`set`, `merge`, `set_default`, etc.).
     pub fn refresh(&mut self) -> Result<&mut Config> {
-        self.cache = match self.kind {
-            // TODO: We need to actually merge in all the stuff
-            ConfigKind::Mutable {
-                ref overrides,
-                ref sources,
-                ref defaults,
-            } => {
-                let mut cache: Value = HashMap::<String, Value>::new().into();
+        self.cache = {
+            let mut cache: Value = HashMap::<String, Value>::new().into();
 
-                // Add defaults
-                for (key, val) in defaults {
-                    key.set(&mut cache, val.clone());
-                }
-
-                // Add sources
-                sources.collect_to(&mut cache)?;
-
-                // Add overrides
-                for (key, val) in overrides {
-                    key.set(&mut cache, val.clone());
-                }
-
-                cache
+            // Add defaults
+            for (key, val) in self.defaults.iter() {
+                key.set(&mut cache, val.clone());
             }
 
-            ConfigKind::Frozen => {
-                return Err(ConfigError::Frozen);
+            // Add sources
+            self.sources.collect_to(&mut cache)?;
+
+            // Add overrides
+            for (key, val) in self.overrides.iter() {
+                key.set(&mut cache, val.clone());
             }
+
+            cache
         };
 
         Ok(self)
@@ -148,16 +91,7 @@ impl Config {
     where
         T: Into<Value>,
     {
-        match self.kind {
-            ConfigKind::Mutable {
-                ref mut defaults, ..
-            } => {
-                defaults.insert(key.parse()?, value.into());
-            }
-
-            ConfigKind::Frozen => return Err(ConfigError::Frozen),
-        };
-
+        self.defaults.insert(key.parse()?, value.into());
         self.refresh()
     }
 
@@ -173,16 +107,7 @@ impl Config {
     where
         T: Into<Value>,
     {
-        match self.kind {
-            ConfigKind::Mutable {
-                ref mut overrides, ..
-            } => {
-                overrides.insert(key.parse()?, value.into());
-            }
-
-            ConfigKind::Frozen => return Err(ConfigError::Frozen),
-        };
-
+        self.overrides.insert(key.parse()?, value.into());
         self.refresh()
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,10 @@ impl Default for Config {
 }
 
 impl Config {
+    pub fn freeze(&mut self) {
+        self.kind = ConfigKind::Frozen
+    }
+
     /// Merge in a configuration property source.
     pub fn merge<T>(&mut self, source: T) -> Result<&mut Config>
     where

--- a/src/de.rs
+++ b/src/de.rs
@@ -141,12 +141,6 @@ impl<'de> de::Deserializer<'de> for Value {
 
 struct StrDeserializer<'a>(&'a str);
 
-impl<'a> StrDeserializer<'a> {
-    fn new(key: &'a str) -> Self {
-        StrDeserializer(key)
-    }
-}
-
 impl<'de, 'a> de::Deserializer<'de> for StrDeserializer<'a> {
     type Error = ConfigError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 //!
 //! See the [examples](https://github.com/mehcode/config-rs/tree/master/examples) for
 //! general usage information.
-#![allow(dead_code)]
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(unknown_lints)]


### PR DESCRIPTION
This actually is twofold: First of all, it adds a `Config::freeze` function, which makes use of the `ConfigKind::Frozen` constructor, which wasn't used before.

I actually am not sure whether this is wanted, but from what I see, this is the only way that enum variant could be used, right? And because it wasn't exported, this was actually never used, so the whole "error if config is frozen" was never required in the first place.
Another option would be to remove the error handling, but I suppose this (freezing the config object) is there for a reason.

---

The second patch removes unused code and the `allow(dead_code)` lint.

---

Review welcome.