### PR TITLE
Create the ConfigBuilder

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,164 @@
+use std::str::FromStr;
+use std::{collections::HashMap, iter::IntoIterator};
+
+use crate::{
+    config::Config, error, error::ConfigError, path::Expression, source::Source, value::Value,
+};
+
+/// A configuration builder
+///
+/// It registers ordered sources of configuration to later build consistent [`Config`] from them.
+/// Configuration sources it defines are defaults, [`Source`]s and overrides.
+///
+/// Defaults are alaways loaded first and can be overwritten by any of two other sources.
+/// Overrides are always loaded last, thus cannot be overridden.
+/// Both can be only set explicitly key by key in code
+/// using [`set_default`](Self::set_default) or [`set_override`](Self::set_override).
+///
+/// An intermediate category, [`Source`], set groups of keys at once implicitly using data coming from external sources
+/// like files, environment variables or others that one implements. Defining a [`Source`] is as simple as implementing
+/// a trait for a struct.
+///
+/// Adding sources, setting defaults and overrides does not invoke any I/O nor builds a config.
+/// It happens on demand when [`build`](Self::build) (or its alternative) is called.
+/// Therefore all errors, related to any of the [`Source`] will only show up then.
+///
+/// # Examples
+///
+/// ```rust
+/// # use config::*;
+/// # use std::error::Error;
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// let mut builder = ConfigBuilder::default();
+///
+/// builder.set_default("default", "1")?;
+/// builder.add_source(File::new("config/settings", FileFormat::Json));
+/// builder.set_override("override", "1")?;
+///
+/// match builder.build() {
+///     Ok(config) => {
+///         // use your config
+///     },
+///     Err(e) => {
+///         // something went wrong
+///     }
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Calls can be chained as well
+/// ```rust
+/// # use std::error::Error;
+/// # use config::*;
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// let mut builder = ConfigBuilder::default();
+///
+/// builder
+///     .set_default("default", "1")?
+///     .add_source(File::new("config/settings", FileFormat::Json))
+///     .add_source(File::new("config/settings.prod", FileFormat::Json))
+///     .set_override("override", "1")?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct ConfigBuilder {
+    defaults: HashMap<Expression, Value>,
+    overrides: HashMap<Expression, Value>,
+    sources: Vec<Box<dyn Source + Send + Sync>>,
+}
+
+impl ConfigBuilder {
+    /// Set a default `value` at `key`
+    ///
+    /// This value can be overwritten by any [`Source`] or override.
+    ///
+    /// # Errors
+    ///
+    /// Fails if `Expression::from_str(key)` fails.
+    pub fn set_default<S, T>(&mut self, key: S, value: T) -> error::Result<&mut ConfigBuilder>
+    where
+        S: AsRef<str>,
+        T: Into<Value>,
+    {
+        self.defaults
+            .insert(Expression::from_str(key.as_ref())?, value.into());
+        Ok(self)
+    }
+
+    /// Registers new [`Source`] in this builder.
+    ///
+    /// Calling this method does not invoke any I/O. [`Source`] is only saved in internal register for later use.
+    pub fn add_source<T>(&mut self, source: T) -> &mut Self
+    where
+        T: Source + Send + Sync + 'static,
+    {
+        self.sources.push(Box::new(source));
+        self
+    }
+
+    /// Set an override
+    ///
+    /// This function sets an overwrite value. It will not be altered by any default or [`Source`]
+    ///
+    /// # Errors
+    ///
+    /// Fails if `Expression::from_str(key)` fails.
+    pub fn set_override<S, T>(&mut self, key: S, value: T) -> error::Result<&mut ConfigBuilder>
+    where
+        S: AsRef<str>,
+        T: Into<Value>,
+    {
+        self.overrides
+            .insert(Expression::from_str(key.as_ref())?, value.into());
+        Ok(self)
+    }
+
+    /// Reads all registered [`Source`]s.
+    ///
+    /// This is the method that invokes all I/O operations.
+    /// For a non consuming alternative see [`build_cloned`](Self::build_cloned)
+    ///
+    /// # Errors
+    /// If source collection fails, be it technical reasons or related to inability to read data as `Config` for different reasons,
+    /// this method returns error.
+    pub fn build(self) -> error::Result<Config> {
+        Self::build_internal(self.defaults, self.overrides, &self.sources)
+    }
+
+    /// Reads all registered [`Source`]s.
+    ///
+    /// Similar to [`build`](Self::build), but it does not take ownership of `ConfigBuilder` to allow later reuse.
+    /// Internally it clones data to achieve it.
+    ///
+    /// # Errors
+    /// If source collection fails, be it technical reasons or related to inability to read data as `Config` for different reasons,
+    /// this method returns error.
+    pub fn build_cloned(&self) -> error::Result<Config> {
+        Self::build_internal(self.defaults.clone(), self.overrides.clone(), &self.sources)
+    }
+
+    fn build_internal(
+        defaults: HashMap<Expression, Value>,
+        overrides: HashMap<Expression, Value>,
+        sources: &Vec<Box<dyn Source + Send + Sync>>,
+    ) -> error::Result<Config> {
+        let mut cache: Value = HashMap::<String, Value>::new().into();
+
+        // Add defaults
+        for (key, val) in defaults.into_iter() {
+            key.set(&mut cache, val);
+        }
+
+        // Add sources
+        sources.collect_to(&mut cache)?;
+
+        // Add overrides
+        for (key, val) in overrides.into_iter() {
+            key.set(&mut cache, val);
+        }
+
+        Ok(Config::new(cache))
+    }
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,9 +1,7 @@
 use std::str::FromStr;
 use std::{collections::HashMap, iter::IntoIterator};
 
-use crate::{
-    config::Config, error, error::ConfigError, path::Expression, source::Source, value::Value,
-};
+use crate::{config::Config, error, path::Expression, source::Source, value::Value};
 
 /// A configuration builder
 ///
@@ -142,7 +140,7 @@ impl ConfigBuilder {
     fn build_internal(
         defaults: HashMap<Expression, Value>,
         overrides: HashMap<Expression, Value>,
-        sources: &Vec<Box<dyn Source + Send + Sync>>,
+        sources: &[Box<dyn Source + Send + Sync>],
     ) -> error::Result<Config> {
         let mut cache: Value = HashMap::<String, Value>::new().into();
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -27,11 +27,10 @@ use crate::{config::Config, error, path::Expression, source::Source, value::Valu
 /// # use config::*;
 /// # use std::error::Error;
 /// # fn main() -> Result<(), Box<dyn Error>> {
-/// let mut builder = ConfigBuilder::default();
-///
-/// builder.set_default("default", "1")?;
-/// builder.add_source(File::new("config/settings", FileFormat::Json));
-/// builder.set_override("override", "1")?;
+/// let mut builder = ConfigBuilder::default()
+///     .set_default("default", "1")?
+///     .add_source(File::new("config/settings", FileFormat::Json))
+///     .set_override("override", "1")?;
 ///
 /// match builder.build() {
 ///     Ok(config) => {
@@ -45,18 +44,16 @@ use crate::{config::Config, error, path::Expression, source::Source, value::Valu
 /// # }
 /// ```
 ///
-/// Calls can be chained as well
+/// Calls can be not chained as well
 /// ```rust
 /// # use std::error::Error;
 /// # use config::*;
 /// # fn main() -> Result<(), Box<dyn Error>> {
 /// let mut builder = ConfigBuilder::default();
-///
-/// builder
-///     .set_default("default", "1")?
-///     .add_source(File::new("config/settings", FileFormat::Json))
-///     .add_source(File::new("config/settings.prod", FileFormat::Json))
-///     .set_override("override", "1")?;
+/// builder = builder.set_default("default", "1")?;
+/// builder = builder.add_source(File::new("config/settings", FileFormat::Json));
+/// builder = builder.add_source(File::new("config/settings.prod", FileFormat::Json));
+/// builder = builder.set_override("override", "1")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -75,7 +72,7 @@ impl ConfigBuilder {
     /// # Errors
     ///
     /// Fails if `Expression::from_str(key)` fails.
-    pub fn set_default<S, T>(&mut self, key: S, value: T) -> error::Result<&mut ConfigBuilder>
+    pub fn set_default<S, T>(mut self, key: S, value: T) -> error::Result<ConfigBuilder>
     where
         S: AsRef<str>,
         T: Into<Value>,
@@ -88,7 +85,7 @@ impl ConfigBuilder {
     /// Registers new [`Source`] in this builder.
     ///
     /// Calling this method does not invoke any I/O. [`Source`] is only saved in internal register for later use.
-    pub fn add_source<T>(&mut self, source: T) -> &mut Self
+    pub fn add_source<T>(mut self, source: T) -> Self
     where
         T: Source + Send + Sync + 'static,
     {
@@ -103,7 +100,7 @@ impl ConfigBuilder {
     /// # Errors
     ///
     /// Fails if `Expression::from_str(key)` fails.
-    pub fn set_override<S, T>(&mut self, key: S, value: T) -> error::Result<&mut ConfigBuilder>
+    pub fn set_override<S, T>(mut self, key: S, value: T) -> error::Result<ConfigBuilder>
     where
         S: AsRef<str>,
         T: Into<Value>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 
+use builder::ConfigBuilder;
 use serde::de::Deserialize;
 use serde::ser::Serialize;
 
@@ -35,7 +36,20 @@ impl Default for Config {
 }
 
 impl Config {
+    pub(crate) fn new(value: Value) -> Self {
+        Config {
+            cache: value,
+            ..Default::default()
+        }
+    }
+
+    /// Creates new [`ConfigBuilder`] instance
+    pub fn builder() -> ConfigBuilder {
+        ConfigBuilder::default()
+    }
+
     /// Merge in a configuration property source.
+    #[deprecated(since = "0.12.0", note = "please use 'ConfigBuilder' instead")]
     pub fn merge<T>(&mut self, source: T) -> Result<&mut Config>
     where
         T: 'static,
@@ -46,6 +60,7 @@ impl Config {
     }
 
     /// Merge in a configuration property source.
+    #[deprecated(since = "0.12.0", note = "please use 'ConfigBuilder' instead")]
     pub fn with_merged<T>(mut self, source: T) -> Result<Self>
     where
         T: 'static,
@@ -61,6 +76,7 @@ impl Config {
     ///
     /// Configuration is automatically refreshed after a mutation
     /// operation (`set`, `merge`, `set_default`, etc.).
+    #[deprecated(since = "0.12.0", note = "please use 'ConfigBuilder' instead")]
     pub fn refresh(&mut self) -> Result<&mut Config> {
         self.cache = {
             let mut cache: Value = HashMap::<String, Value>::new().into();
@@ -85,6 +101,7 @@ impl Config {
     }
 
     /// Set a default `value` at `key`
+    #[deprecated(since = "0.12.0", note = "please use 'ConfigBuilder' instead")]
     pub fn set_default<T>(&mut self, key: &str, value: T) -> Result<&mut Config>
     where
         T: Into<Value>,
@@ -101,6 +118,7 @@ impl Config {
     /// # Warning
     ///
     /// Errors if config is frozen
+    #[deprecated(since = "0.12.0", note = "please use 'ConfigBuilder' instead")]
     pub fn set<T>(&mut self, key: &str, value: T) -> Result<&mut Config>
     where
         T: Into<Value>,
@@ -109,6 +127,7 @@ impl Config {
         self.refresh()
     }
 
+    #[deprecated(since = "0.12.0", note = "please use 'ConfigBuilder' instead")]
     pub fn set_once(&mut self, key: &str, value: Value) -> Result<()> {
         let expr: path::Expression = key.parse()?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,6 +56,8 @@ impl Config {
         T: Source + Send + Sync,
     {
         self.sources.push(Box::new(source));
+
+        #[allow(deprecated)]
         self.refresh()
     }
 
@@ -67,6 +69,8 @@ impl Config {
         T: Source + Send + Sync,
     {
         self.sources.push(Box::new(source));
+
+        #[allow(deprecated)]
         self.refresh()?;
         Ok(self)
     }
@@ -107,6 +111,8 @@ impl Config {
         T: Into<Value>,
     {
         self.defaults.insert(key.parse()?, value.into());
+
+        #[allow(deprecated)]
         self.refresh()
     }
 
@@ -124,6 +130,8 @@ impl Config {
         T: Into<Value>,
     {
         self.overrides.insert(key.parse()?, value.into());
+
+        #[allow(deprecated)]
         self.refresh()
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 
-use builder::ConfigBuilder;
+use crate::builder::ConfigBuilder;
 use serde::de::Deserialize;
 use serde::ser::Serialize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ extern crate ini;
 #[cfg(feature = "ron")]
 extern crate ron;
 
+mod builder;
 mod config;
 mod de;
 mod env;
@@ -61,6 +62,7 @@ mod ser;
 mod source;
 mod value;
 
+pub use crate::builder::ConfigBuilder;
 pub use crate::config::Config;
 pub use crate::env::Environment;
 pub use crate::error::ConfigError;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -27,6 +27,8 @@ impl ConfigSerializer {
                 )))
             }
         };
+
+        #[allow(deprecated)]
         self.output.set(&key, value.into())?;
         Ok(())
     }

--- a/src/source.rs
+++ b/src/source.rs
@@ -55,6 +55,26 @@ impl Source for Vec<Box<dyn Source + Send + Sync>> {
     }
 }
 
+impl Source for [Box<dyn Source + Send + Sync>] {
+    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
+        Box::new(self.to_owned())
+    }
+
+    fn collect(&self) -> Result<HashMap<String, Value>> {
+        let mut cache: Value = HashMap::<String, Value>::new().into();
+
+        for source in self {
+            source.collect_to(&mut cache)?;
+        }
+
+        if let ValueKind::Table(table) = cache.kind {
+            Ok(table)
+        } else {
+            unreachable!();
+        }
+    }
+}
+
 impl<T> Source for Vec<T>
 where
     T: Source + Sync + Send,

--- a/tests/datetime.rs
+++ b/tests/datetime.rs
@@ -14,9 +14,7 @@ use chrono::{DateTime, TimeZone, Utc};
 use config::*;
 
 fn make() -> Config {
-    let mut builder = Config::builder();
-
-    builder
+    Config::builder()
         .add_source(File::from_str(
             r#"
             {
@@ -58,9 +56,9 @@ fn make() -> Config {
             )
             "#,
             FileFormat::Ron,
-        ));
-
-    builder.build().unwrap()
+        ))
+        .build()
+        .unwrap()
 }
 
 #[test]

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -10,16 +10,17 @@ use std::path::PathBuf;
 use config::*;
 
 fn make() -> Config {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings", FileFormat::Toml));
-    c.build().unwrap()
+    Config::builder()
+        .add_source(File::new("tests/Settings", FileFormat::Toml))
+        .build()
+        .unwrap()
 }
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings-invalid", FileFormat::Toml));
-    let res = c.build();
+    let res = Config::builder()
+        .add_source(File::new("tests/Settings-invalid", FileFormat::Toml))
+        .build();
 
     let path: PathBuf = ["tests", "Settings-invalid.toml"].iter().collect();
 
@@ -120,9 +121,13 @@ inner:
     test: ABC
 "#;
 
-    let mut cfg = Config::builder();
-    cfg.add_source(File::from_str(CFG, FileFormat::Yaml));
-    let e = cfg.build().unwrap().try_into::<Outer>().unwrap_err();
+    let e = Config::builder()
+        .add_source(File::from_str(CFG, FileFormat::Yaml))
+        .build()
+        .unwrap()
+        .try_into::<Outer>()
+        .unwrap_err();
+
     if let ConfigError::Type {
         key: Some(path), ..
     } = e

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -6,18 +6,18 @@ use config::*;
 
 #[test]
 fn test_file_not_required() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/NoSettings", FileFormat::Yaml).required(false));
-    let res = c.build();
+    let res = Config::builder()
+        .add_source(File::new("tests/NoSettings", FileFormat::Yaml).required(false))
+        .build();
 
     assert!(res.is_ok());
 }
 
 #[test]
 fn test_file_required_not_found() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/NoSettings", FileFormat::Yaml));
-    let res = c.build();
+    let res = Config::builder()
+        .add_source(File::new("tests/NoSettings", FileFormat::Yaml))
+        .build();
 
     assert!(res.is_err());
     assert_eq!(
@@ -28,10 +28,10 @@ fn test_file_required_not_found() {
 
 #[test]
 fn test_file_auto() {
-    let mut builder = Config::builder();
-    builder.add_source(File::with_name("tests/Settings-production"));
-
-    let c = builder.build().unwrap();
+    let c = Config::builder()
+        .add_source(File::with_name("tests/Settings-production"))
+        .build()
+        .unwrap();
 
     assert_eq!(c.get("debug").ok(), Some(false));
     assert_eq!(c.get("production").ok(), Some(true));
@@ -39,9 +39,9 @@ fn test_file_auto() {
 
 #[test]
 fn test_file_auto_not_found() {
-    let mut c = Config::builder();
-    c.add_source(File::with_name("tests/NoSettings"));
-    let res = c.build();
+    let res = Config::builder()
+        .add_source(File::with_name("tests/NoSettings"))
+        .build();
 
     assert!(res.is_err());
     assert_eq!(
@@ -52,10 +52,10 @@ fn test_file_auto_not_found() {
 
 #[test]
 fn test_file_ext() {
-    let mut builder = Config::builder();
-    builder.add_source(File::with_name("tests/Settings.json"));
-
-    let c = builder.build().unwrap();
+    let c = Config::builder()
+        .add_source(File::with_name("tests/Settings.json"))
+        .build()
+        .unwrap();
 
     assert_eq!(c.get("debug").ok(), Some(true));
     assert_eq!(c.get("production").ok(), Some(false));

--- a/tests/file_hjson.rs
+++ b/tests/file_hjson.rs
@@ -35,11 +35,9 @@ struct Settings {
 }
 
 fn make() -> Config {
-    let mut c = Config::default();
-    c.merge(File::new("tests/Settings", FileFormat::Hjson))
-        .unwrap();
-
-    c
+    let mut c = Config::builder();
+    c.add_source(File::new("tests/Settings", FileFormat::Hjson));
+    c.build().unwrap()
 }
 
 #[test]
@@ -68,8 +66,9 @@ fn test_file() {
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::default();
-    let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Hjson));
+    let mut c = Config::builder();
+    c.add_source(File::new("tests/Settings-invalid", FileFormat::Hjson));
+    let res = c.build();
 
     let path: PathBuf = ["tests", "Settings-invalid.hjson"].iter().collect();
 

--- a/tests/file_hjson.rs
+++ b/tests/file_hjson.rs
@@ -35,9 +35,10 @@ struct Settings {
 }
 
 fn make() -> Config {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings", FileFormat::Hjson));
-    c.build().unwrap()
+    Config::builder()
+        .add_source(File::new("tests/Settings", FileFormat::Hjson))
+        .build()
+        .unwrap()
 }
 
 #[test]
@@ -66,9 +67,9 @@ fn test_file() {
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings-invalid", FileFormat::Hjson));
-    let res = c.build();
+    let res = Config::builder()
+        .add_source(File::new("tests/Settings-invalid", FileFormat::Hjson))
+        .build();
 
     let path: PathBuf = ["tests", "Settings-invalid.hjson"].iter().collect();
 

--- a/tests/file_ini.rs
+++ b/tests/file_ini.rs
@@ -28,9 +28,10 @@ struct Settings {
 }
 
 fn make() -> Config {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings", FileFormat::Ini));
-    c.build().unwrap()
+    Config::builder()
+        .add_source(File::new("tests/Settings", FileFormat::Ini))
+        .build()
+        .unwrap()
 }
 
 #[test]
@@ -55,9 +56,9 @@ fn test_file() {
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings-invalid", FileFormat::Ini));
-    let res = c.build();
+    let res = Config::builder()
+        .add_source(File::new("tests/Settings-invalid", FileFormat::Ini))
+        .build();
 
     let path: PathBuf = ["tests", "Settings-invalid.ini"].iter().collect();
 

--- a/tests/file_json.rs
+++ b/tests/file_json.rs
@@ -35,11 +35,9 @@ struct Settings {
 }
 
 fn make() -> Config {
-    let mut c = Config::default();
-    c.merge(File::new("tests/Settings", FileFormat::Json))
-        .unwrap();
-
-    c
+    let mut c = Config::builder();
+    c.add_source(File::new("tests/Settings", FileFormat::Json));
+    c.build().unwrap()
 }
 
 #[test]
@@ -68,8 +66,9 @@ fn test_file() {
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::default();
-    let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Json));
+    let mut c = Config::builder();
+    c.add_source(File::new("tests/Settings-invalid", FileFormat::Json));
+    let res = c.build();
 
     let path_with_extension: PathBuf = ["tests", "Settings-invalid.json"].iter().collect();
 
@@ -85,17 +84,17 @@ fn test_error_parse() {
 
 #[test]
 fn test_json_vec() {
-    let c = Config::default()
-        .merge(File::from_str(
-            r#"
+    let mut builder = Config::builder();
+    builder.add_source(File::from_str(
+        r#"
             {
               "WASTE": ["example_dir1", "example_dir2"]
             }
             "#,
-            FileFormat::Json,
-        ))
-        .unwrap()
-        .clone();
+        FileFormat::Json,
+    ));
+
+    let c = builder.build().unwrap();
 
     let v = c.get_array("WASTE").unwrap();
     let mut vi = v.into_iter();

--- a/tests/file_json.rs
+++ b/tests/file_json.rs
@@ -35,9 +35,10 @@ struct Settings {
 }
 
 fn make() -> Config {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings", FileFormat::Json));
-    c.build().unwrap()
+    Config::builder()
+        .add_source(File::new("tests/Settings", FileFormat::Json))
+        .build()
+        .unwrap()
 }
 
 #[test]
@@ -66,9 +67,9 @@ fn test_file() {
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings-invalid", FileFormat::Json));
-    let res = c.build();
+    let res = Config::builder()
+        .add_source(File::new("tests/Settings-invalid", FileFormat::Json))
+        .build();
 
     let path_with_extension: PathBuf = ["tests", "Settings-invalid.json"].iter().collect();
 
@@ -84,17 +85,17 @@ fn test_error_parse() {
 
 #[test]
 fn test_json_vec() {
-    let mut builder = Config::builder();
-    builder.add_source(File::from_str(
-        r#"
+    let c = Config::builder()
+        .add_source(File::from_str(
+            r#"
             {
               "WASTE": ["example_dir1", "example_dir2"]
             }
             "#,
-        FileFormat::Json,
-    ));
-
-    let c = builder.build().unwrap();
+            FileFormat::Json,
+        ))
+        .build()
+        .unwrap();
 
     let v = c.get_array("WASTE").unwrap();
     let mut vi = v.into_iter();

--- a/tests/file_ron.rs
+++ b/tests/file_ron.rs
@@ -36,9 +36,10 @@ struct Settings {
 }
 
 fn make() -> Config {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings", FileFormat::Ron));
-    c.build().unwrap()
+    Config::builder()
+        .add_source(File::new("tests/Settings", FileFormat::Ron))
+        .build()
+        .unwrap()
 }
 
 #[test]
@@ -68,9 +69,9 @@ fn test_file() {
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings-invalid", FileFormat::Ron));
-    let res = c.build();
+    let res = Config::builder()
+        .add_source(File::new("tests/Settings-invalid", FileFormat::Ron))
+        .build();
 
     let path_with_extension: PathBuf = ["tests", "Settings-invalid.ron"].iter().collect();
 

--- a/tests/file_toml.rs
+++ b/tests/file_toml.rs
@@ -44,9 +44,10 @@ struct Settings {
 
 #[cfg(test)]
 fn make() -> Config {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings", FileFormat::Toml));
-    c.build().unwrap()
+    Config::builder()
+        .add_source(File::new("tests/Settings", FileFormat::Toml))
+        .build()
+        .unwrap()
 }
 
 #[test]
@@ -77,9 +78,9 @@ fn test_file() {
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings-invalid", FileFormat::Toml));
-    let res = c.build();
+    let res = Config::builder()
+        .add_source(File::new("tests/Settings-invalid", FileFormat::Toml))
+        .build();
 
     let path_with_extension: PathBuf = ["tests", "Settings-invalid.toml"].iter().collect();
 

--- a/tests/file_toml.rs
+++ b/tests/file_toml.rs
@@ -44,11 +44,9 @@ struct Settings {
 
 #[cfg(test)]
 fn make() -> Config {
-    let mut c = Config::default();
-    c.merge(File::new("tests/Settings", FileFormat::Toml))
-        .unwrap();
-
-    c
+    let mut c = Config::builder();
+    c.add_source(File::new("tests/Settings", FileFormat::Toml));
+    c.build().unwrap()
 }
 
 #[test]
@@ -79,8 +77,9 @@ fn test_file() {
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::default();
-    let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Toml));
+    let mut c = Config::builder();
+    c.add_source(File::new("tests/Settings-invalid", FileFormat::Toml));
+    let res = c.build();
 
     let path_with_extension: PathBuf = ["tests", "Settings-invalid.toml"].iter().collect();
 

--- a/tests/file_yaml.rs
+++ b/tests/file_yaml.rs
@@ -35,11 +35,9 @@ struct Settings {
 }
 
 fn make() -> Config {
-    let mut c = Config::default();
-    c.merge(File::new("tests/Settings", FileFormat::Yaml))
-        .unwrap();
-
-    c
+    let mut c = Config::builder();
+    c.add_source(File::new("tests/Settings", FileFormat::Yaml));
+    c.build().unwrap()
 }
 
 #[test]
@@ -68,8 +66,9 @@ fn test_file() {
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::default();
-    let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Yaml));
+    let mut c = Config::builder();
+    c.add_source(File::new("tests/Settings-invalid", FileFormat::Yaml));
+    let res = c.build();
 
     let path_with_extension: PathBuf = ["tests", "Settings-invalid.yaml"].iter().collect();
 

--- a/tests/file_yaml.rs
+++ b/tests/file_yaml.rs
@@ -35,9 +35,10 @@ struct Settings {
 }
 
 fn make() -> Config {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings", FileFormat::Yaml));
-    c.build().unwrap()
+    Config::builder()
+        .add_source(File::new("tests/Settings", FileFormat::Yaml))
+        .build()
+        .unwrap()
 }
 
 #[test]
@@ -66,9 +67,9 @@ fn test_file() {
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings-invalid", FileFormat::Yaml));
-    let res = c.build();
+    let res = Config::builder()
+        .add_source(File::new("tests/Settings-invalid", FileFormat::Yaml))
+        .build();
 
     let path_with_extension: PathBuf = ["tests", "Settings-invalid.yaml"].iter().collect();
 

--- a/tests/get.rs
+++ b/tests/get.rs
@@ -31,9 +31,10 @@ struct Settings {
 }
 
 fn make() -> Config {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings", FileFormat::Toml));
-    c.build().unwrap()
+    Config::builder()
+        .add_source(File::new("tests/Settings", FileFormat::Toml))
+        .build()
+        .unwrap()
 }
 
 #[test]

--- a/tests/legacy/datetime.rs
+++ b/tests/legacy/datetime.rs
@@ -10,14 +10,12 @@
 extern crate chrono;
 extern crate config;
 
-use chrono::{DateTime, TimeZone, Utc};
-use config::*;
+use self::chrono::{DateTime, TimeZone, Utc};
+use self::config::*;
 
 fn make() -> Config {
-    let mut builder = Config::builder();
-
-    builder
-        .add_source(File::from_str(
+    Config::default()
+        .merge(File::from_str(
             r#"
             {
                 "json_datetime": "2017-05-10T02:14:53Z"
@@ -25,19 +23,22 @@ fn make() -> Config {
             "#,
             FileFormat::Json,
         ))
-        .add_source(File::from_str(
+        .unwrap()
+        .merge(File::from_str(
             r#"
             yaml_datetime: 2017-06-12T10:58:30Z
             "#,
             FileFormat::Yaml,
         ))
-        .add_source(File::from_str(
+        .unwrap()
+        .merge(File::from_str(
             r#"
             toml_datetime = 2017-05-11T14:55:15Z
             "#,
             FileFormat::Toml,
         ))
-        .add_source(File::from_str(
+        .unwrap()
+        .merge(File::from_str(
             r#"
             {
                 "hjson_datetime": "2017-05-10T02:14:53Z"
@@ -45,22 +46,24 @@ fn make() -> Config {
             "#,
             FileFormat::Hjson,
         ))
-        .add_source(File::from_str(
+        .unwrap()
+        .merge(File::from_str(
             r#"
                 ini_datetime = 2017-05-10T02:14:53Z
             "#,
             FileFormat::Ini,
         ))
-        .add_source(File::from_str(
+        .unwrap()
+        .merge(File::from_str(
             r#"
             (
                 ron_datetime: "2021-04-19T11:33:02Z"
             )
             "#,
             FileFormat::Ron,
-        ));
-
-    builder.build().unwrap()
+        ))
+        .unwrap()
+        .clone()
 }
 
 #[test]

--- a/tests/legacy/env.rs
+++ b/tests/legacy/env.rs
@@ -8,85 +8,6 @@ use std::env;
 /// Reminder that tests using env variables need to use different env variable names, since
 /// tests can be run in parallel
 
-#[test]
-fn test_default() {
-    env::set_var("A_B_C", "abc");
-
-    let environment = Environment::new();
-
-    assert!(environment.collect().unwrap().contains_key("a_b_c"));
-
-    env::remove_var("A_B_C");
-}
-
-#[test]
-fn test_prefix_is_removed_from_key() {
-    env::set_var("B_A_C", "abc");
-
-    let environment = Environment::with_prefix("B");
-
-    assert!(environment.collect().unwrap().contains_key("a_c"));
-
-    env::remove_var("B_A_C");
-}
-
-#[test]
-fn test_prefix_with_variant_forms_of_spelling() {
-    env::set_var("a_A_C", "abc");
-
-    let environment = Environment::with_prefix("a");
-
-    assert!(environment.collect().unwrap().contains_key("a_c"));
-
-    env::remove_var("a_A_C");
-    env::set_var("aB_A_C", "abc");
-
-    let environment = Environment::with_prefix("aB");
-
-    assert!(environment.collect().unwrap().contains_key("a_c"));
-
-    env::remove_var("aB_A_C");
-    env::set_var("Ab_A_C", "abc");
-
-    let environment = Environment::with_prefix("ab");
-
-    assert!(environment.collect().unwrap().contains_key("a_c"));
-
-    env::remove_var("Ab_A_C");
-}
-
-#[test]
-fn test_separator_behavior() {
-    env::set_var("C_B_A", "abc");
-
-    let environment = Environment::with_prefix("C").separator("_");
-
-    assert!(environment.collect().unwrap().contains_key("b.a"));
-
-    env::remove_var("C_B_A");
-}
-
-#[test]
-fn test_empty_value_is_ignored() {
-    env::set_var("C_A_B", "");
-
-    let environment = Environment::new().ignore_empty(true);
-
-    assert!(!environment.collect().unwrap().contains_key("c_a_b"));
-
-    env::remove_var("C_A_B");
-}
-
-#[test]
-fn test_custom_separator_behavior() {
-    env::set_var("C.B.A", "abc");
-
-    let environment = Environment::with_prefix("C").separator(".");
-
-    assert!(environment.collect().unwrap().contains_key("b.a"));
-
-    env::remove_var("C.B.A");
-}
 
 #[test]
 fn test_parse_int() {
@@ -105,13 +26,11 @@ fn test_parse_int() {
     env::set_var("INT_VAL", "42");
 
     let environment = Environment::new().try_parsing(true);
+    let mut config = Config::default();
 
-    let config = Config::builder()
-        .set_default("tag", "Int")
-        .unwrap()
-        .add_source(environment)
-        .build()
-        .unwrap();
+    config.set("tag", "Int").unwrap();
+
+    config.merge(environment).unwrap();
 
     let config: TestIntEnum = config.try_into().unwrap();
 
@@ -137,13 +56,11 @@ fn test_parse_float() {
     env::set_var("FLOAT_VAL", "42.3");
 
     let environment = Environment::new().try_parsing(true);
+    let mut config = Config::default();
 
-    let config = Config::builder()
-        .set_default("tag", "Float")
-        .unwrap()
-        .add_source(environment)
-        .build()
-        .unwrap();
+    config.set("tag", "Float").unwrap();
+
+    config.merge(environment).unwrap();
 
     let config: TestFloatEnum = config.try_into().unwrap();
 
@@ -172,13 +89,11 @@ fn test_parse_bool() {
     env::set_var("BOOL_VAL", "true");
 
     let environment = Environment::new().try_parsing(true);
+    let mut config = Config::default();
 
-    let config = Config::builder()
-        .set_default("tag", "Bool")
-        .unwrap()
-        .add_source(environment)
-        .build()
-        .unwrap();
+    config.set("tag", "Bool").unwrap();
+
+    config.merge(environment).unwrap();
 
     let config: TestBoolEnum = config.try_into().unwrap();
 
@@ -208,13 +123,11 @@ fn test_parse_off_int() {
     env::set_var("INT_VAL_1", "42");
 
     let environment = Environment::new().try_parsing(false);
+    let mut config = Config::default();
 
-    let config = Config::builder()
-        .set_default("tag", "Int")
-        .unwrap()
-        .add_source(environment)
-        .build()
-        .unwrap();
+    config.set("tag", "Int").unwrap();
+
+    config.merge(environment).unwrap();
 
     env::remove_var("INT_VAL_1");
 
@@ -239,13 +152,11 @@ fn test_parse_off_float() {
     env::set_var("FLOAT_VAL_1", "42.3");
 
     let environment = Environment::new().try_parsing(false);
+    let mut config = Config::default();
 
-    let config = Config::builder()
-        .set_default("tag", "Float")
-        .unwrap()
-        .add_source(environment)
-        .build()
-        .unwrap();
+    config.set("tag", "Float").unwrap();
+
+    config.merge(environment).unwrap();
 
     env::remove_var("FLOAT_VAL_1");
 
@@ -270,13 +181,11 @@ fn test_parse_off_bool() {
     env::set_var("BOOL_VAL_1", "true");
 
     let environment = Environment::new().try_parsing(false);
+    let mut config = Config::default();
 
-    let config = Config::builder()
-        .set_default("tag", "Bool")
-        .unwrap()
-        .add_source(environment)
-        .build()
-        .unwrap();
+    config.set("tag", "Bool").unwrap();
+
+    config.merge(environment).unwrap();
 
     env::remove_var("BOOL_VAL_1");
 
@@ -301,13 +210,11 @@ fn test_parse_int_fail() {
     env::set_var("INT_VAL_2", "not an int");
 
     let environment = Environment::new().try_parsing(true);
+    let mut config = Config::default();
 
-    let config = Config::builder()
-        .set_default("tag", "Int")
-        .unwrap()
-        .add_source(environment)
-        .build()
-        .unwrap();
+    config.set("tag", "Int").unwrap();
+
+    config.merge(environment).unwrap();
 
     env::remove_var("INT_VAL_2");
 
@@ -332,13 +239,11 @@ fn test_parse_float_fail() {
     env::set_var("FLOAT_VAL_2", "not a float");
 
     let environment = Environment::new().try_parsing(true);
+    let mut config = Config::default();
 
-    let config = Config::builder()
-        .set_default("tag", "Float")
-        .unwrap()
-        .add_source(environment)
-        .build()
-        .unwrap();
+    config.set("tag", "Float").unwrap();
+
+    config.merge(environment).unwrap();
 
     env::remove_var("FLOAT_VAL_2");
 
@@ -363,13 +268,11 @@ fn test_parse_bool_fail() {
     env::set_var("BOOL_VAL_2", "not a bool");
 
     let environment = Environment::new().try_parsing(true);
+    let mut config = Config::default();
 
-    let config = Config::builder()
-        .set_default("tag", "Bool")
-        .unwrap()
-        .add_source(environment)
-        .build()
-        .unwrap();
+    config.set("tag", "Bool").unwrap();
+
+    config.merge(environment).unwrap();
 
     env::remove_var("BOOL_VAL_2");
 
@@ -393,13 +296,11 @@ fn test_parse_string() {
     env::set_var("STRING_VAL", "test string");
 
     let environment = Environment::new().try_parsing(true);
+    let mut config = Config::default();
 
-    let config = Config::builder()
-        .set_default("tag", "String")
-        .unwrap()
-        .add_source(environment)
-        .build()
-        .unwrap();
+    config.set("tag", "String").unwrap();
+
+    config.merge(environment).unwrap();
 
     let config: TestStringEnum = config.try_into().unwrap();
 
@@ -429,13 +330,11 @@ fn test_parse_off_string() {
     env::set_var("STRING_VAL_1", "test string");
 
     let environment = Environment::new().try_parsing(false);
+    let mut config = Config::default();
 
-    let config = Config::builder()
-        .set_default("tag", "String")
-        .unwrap()
-        .add_source(environment)
-        .build()
-        .unwrap();
+    config.set("tag", "String").unwrap();
+
+    config.merge(environment).unwrap();
 
     let config: TestStringEnum = config.try_into().unwrap();
 

--- a/tests/legacy/errors.rs
+++ b/tests/legacy/errors.rs
@@ -2,24 +2,22 @@
 
 extern crate config;
 
-#[macro_use]
-extern crate serde_derive;
-
 use std::path::PathBuf;
 
-use config::*;
+use self::config::*;
 
 fn make() -> Config {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings", FileFormat::Toml));
-    c.build().unwrap()
+    let mut c = Config::default();
+    c.merge(File::new("tests/Settings", FileFormat::Toml))
+        .unwrap();
+
+    c
 }
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings-invalid", FileFormat::Toml));
-    let res = c.build();
+    let mut c = Config::default();
+    let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Toml));
 
     let path: PathBuf = ["tests", "Settings-invalid.toml"].iter().collect();
 
@@ -120,9 +118,9 @@ inner:
     test: ABC
 "#;
 
-    let mut cfg = Config::builder();
-    cfg.add_source(File::from_str(CFG, FileFormat::Yaml));
-    let e = cfg.build().unwrap().try_into::<Outer>().unwrap_err();
+    let mut cfg = Config::default();
+    cfg.merge(File::from_str(CFG, FileFormat::Yaml)).unwrap();
+    let e = cfg.try_into::<Outer>().unwrap_err();
     if let ConfigError::Type {
         key: Some(path), ..
     } = e

--- a/tests/legacy/file.rs
+++ b/tests/legacy/file.rs
@@ -2,22 +2,20 @@
 
 extern crate config;
 
-use config::*;
+use self::config::*;
 
 #[test]
 fn test_file_not_required() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/NoSettings", FileFormat::Yaml).required(false));
-    let res = c.build();
+    let mut c = Config::default();
+    let res = c.merge(File::new("tests/NoSettings", FileFormat::Yaml).required(false));
 
     assert!(res.is_ok());
 }
 
 #[test]
 fn test_file_required_not_found() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/NoSettings", FileFormat::Yaml));
-    let res = c.build();
+    let mut c = Config::default();
+    let res = c.merge(File::new("tests/NoSettings", FileFormat::Yaml));
 
     assert!(res.is_err());
     assert_eq!(
@@ -28,10 +26,9 @@ fn test_file_required_not_found() {
 
 #[test]
 fn test_file_auto() {
-    let mut builder = Config::builder();
-    builder.add_source(File::with_name("tests/Settings-production"));
-
-    let c = builder.build().unwrap();
+    let mut c = Config::default();
+    c.merge(File::with_name("tests/Settings-production"))
+        .unwrap();
 
     assert_eq!(c.get("debug").ok(), Some(false));
     assert_eq!(c.get("production").ok(), Some(true));
@@ -39,9 +36,8 @@ fn test_file_auto() {
 
 #[test]
 fn test_file_auto_not_found() {
-    let mut c = Config::builder();
-    c.add_source(File::with_name("tests/NoSettings"));
-    let res = c.build();
+    let mut c = Config::default();
+    let res = c.merge(File::with_name("tests/NoSettings"));
 
     assert!(res.is_err());
     assert_eq!(
@@ -52,10 +48,8 @@ fn test_file_auto_not_found() {
 
 #[test]
 fn test_file_ext() {
-    let mut builder = Config::builder();
-    builder.add_source(File::with_name("tests/Settings.json"));
-
-    let c = builder.build().unwrap();
+    let mut c = Config::default();
+    c.merge(File::with_name("tests/Settings.json")).unwrap();
 
     assert_eq!(c.get("debug").ok(), Some(true));
     assert_eq!(c.get("production").ok(), Some(false));

--- a/tests/legacy/file_ini.rs
+++ b/tests/legacy/file_ini.rs
@@ -4,12 +4,9 @@ extern crate config;
 extern crate float_cmp;
 extern crate serde;
 
-#[macro_use]
-extern crate serde_derive;
-
 use std::path::PathBuf;
 
-use config::*;
+use self::config::*;
 
 #[derive(Debug, Deserialize, PartialEq)]
 struct Place {
@@ -28,9 +25,10 @@ struct Settings {
 }
 
 fn make() -> Config {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings", FileFormat::Ini));
-    c.build().unwrap()
+    let mut c = Config::default();
+    c.merge(File::new("tests/Settings", FileFormat::Ini))
+        .unwrap();
+    c
 }
 
 #[test]
@@ -55,9 +53,8 @@ fn test_file() {
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings-invalid", FileFormat::Ini));
-    let res = c.build();
+    let mut c = Config::default();
+    let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Ini));
 
     let path: PathBuf = ["tests", "Settings-invalid.ini"].iter().collect();
 

--- a/tests/legacy/file_json.rs
+++ b/tests/legacy/file_json.rs
@@ -1,21 +1,17 @@
-#![cfg(feature = "ron")]
+#![cfg(feature = "json")]
 
 extern crate config;
 extern crate float_cmp;
 extern crate serde;
 
-#[macro_use]
-extern crate serde_derive;
-
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use config::*;
-use float_cmp::ApproxEqUlps;
+use self::config::*;
+use self::float_cmp::ApproxEqUlps;
 
 #[derive(Debug, Deserialize)]
 struct Place {
-    initials: (char, char),
     name: String,
     longitude: f64,
     latitude: f64,
@@ -36,9 +32,11 @@ struct Settings {
 }
 
 fn make() -> Config {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings", FileFormat::Ron));
-    c.build().unwrap()
+    let mut c = Config::default();
+    c.merge(File::new("tests/Settings", FileFormat::Json))
+        .unwrap();
+
+    c
 }
 
 #[test]
@@ -50,7 +48,6 @@ fn test_file() {
 
     assert!(s.debug.approx_eq_ulps(&1.0, 2));
     assert_eq!(s.production, Some("false".to_string()));
-    assert_eq!(s.place.initials, ('T', 'P'));
     assert_eq!(s.place.name, "Torre di Pisa");
     assert!(s.place.longitude.approx_eq_ulps(&43.7224985, 2));
     assert!(s.place.latitude.approx_eq_ulps(&10.3970522, 2));
@@ -68,15 +65,38 @@ fn test_file() {
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings-invalid", FileFormat::Ron));
-    let res = c.build();
+    let mut c = Config::default();
+    let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Json));
 
-    let path_with_extension: PathBuf = ["tests", "Settings-invalid.ron"].iter().collect();
+    let path_with_extension: PathBuf = ["tests", "Settings-invalid.json"].iter().collect();
 
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        format!("4:1: Expected colon in {}", path_with_extension.display())
+        format!(
+            "expected `:` at line 4 column 1 in {}",
+            path_with_extension.display()
+        )
     );
+}
+
+#[test]
+fn test_json_vec() {
+    let c = Config::default()
+        .merge(File::from_str(
+            r#"
+            {
+              "WASTE": ["example_dir1", "example_dir2"]
+            }
+            "#,
+            FileFormat::Json,
+        ))
+        .unwrap()
+        .clone();
+
+    let v = c.get_array("WASTE").unwrap();
+    let mut vi = v.into_iter();
+    assert_eq!(vi.next().unwrap().into_string().unwrap(), "example_dir1");
+    assert_eq!(vi.next().unwrap().into_string().unwrap(), "example_dir2");
+    assert!(vi.next().is_none());
 }

--- a/tests/legacy/file_ron.rs
+++ b/tests/legacy/file_ron.rs
@@ -4,14 +4,11 @@ extern crate config;
 extern crate float_cmp;
 extern crate serde;
 
-#[macro_use]
-extern crate serde_derive;
-
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use config::*;
-use float_cmp::ApproxEqUlps;
+use self::config::*;
+use self::float_cmp::ApproxEqUlps;
 
 #[derive(Debug, Deserialize)]
 struct Place {
@@ -36,9 +33,11 @@ struct Settings {
 }
 
 fn make() -> Config {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings", FileFormat::Ron));
-    c.build().unwrap()
+    let mut c = Config::default();
+    c.merge(File::new("tests/Settings", FileFormat::Ron))
+        .unwrap();
+
+    c
 }
 
 #[test]
@@ -68,9 +67,8 @@ fn test_file() {
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings-invalid", FileFormat::Ron));
-    let res = c.build();
+    let mut c = Config::default();
+    let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Ron));
 
     let path_with_extension: PathBuf = ["tests", "Settings-invalid.ron"].iter().collect();
 

--- a/tests/legacy/file_yaml.rs
+++ b/tests/legacy/file_yaml.rs
@@ -1,21 +1,17 @@
-#![cfg(feature = "ron")]
+#![cfg(feature = "yaml")]
 
 extern crate config;
 extern crate float_cmp;
 extern crate serde;
 
-#[macro_use]
-extern crate serde_derive;
-
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use config::*;
-use float_cmp::ApproxEqUlps;
+use self::config::*;
+use self::float_cmp::ApproxEqUlps;
 
 #[derive(Debug, Deserialize)]
 struct Place {
-    initials: (char, char),
     name: String,
     longitude: f64,
     latitude: f64,
@@ -36,9 +32,11 @@ struct Settings {
 }
 
 fn make() -> Config {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings", FileFormat::Ron));
-    c.build().unwrap()
+    let mut c = Config::default();
+    c.merge(File::new("tests/Settings", FileFormat::Yaml))
+        .unwrap();
+
+    c
 }
 
 #[test]
@@ -50,7 +48,6 @@ fn test_file() {
 
     assert!(s.debug.approx_eq_ulps(&1.0, 2));
     assert_eq!(s.production, Some("false".to_string()));
-    assert_eq!(s.place.initials, ('T', 'P'));
     assert_eq!(s.place.name, "Torre di Pisa");
     assert!(s.place.longitude.approx_eq_ulps(&43.7224985, 2));
     assert!(s.place.latitude.approx_eq_ulps(&10.3970522, 2));
@@ -68,15 +65,18 @@ fn test_file() {
 
 #[test]
 fn test_error_parse() {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings-invalid", FileFormat::Ron));
-    let res = c.build();
+    let mut c = Config::default();
+    let res = c.merge(File::new("tests/Settings-invalid", FileFormat::Yaml));
 
-    let path_with_extension: PathBuf = ["tests", "Settings-invalid.ron"].iter().collect();
+    let path_with_extension: PathBuf = ["tests", "Settings-invalid.yaml"].iter().collect();
 
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
-        format!("4:1: Expected colon in {}", path_with_extension.display())
+        format!(
+            "while parsing a block mapping, did not find expected key at \
+         line 2 column 1 in {}",
+            path_with_extension.display()
+        )
     );
 }

--- a/tests/legacy/get.rs
+++ b/tests/legacy/get.rs
@@ -4,13 +4,10 @@ extern crate config;
 extern crate float_cmp;
 extern crate serde;
 
-#[macro_use]
-extern crate serde_derive;
-
 use std::collections::{HashMap, HashSet};
 
-use config::*;
-use float_cmp::ApproxEqUlps;
+use self::config::*;
+use self::float_cmp::ApproxEqUlps;
 
 #[derive(Debug, Deserialize)]
 struct Place {
@@ -31,9 +28,11 @@ struct Settings {
 }
 
 fn make() -> Config {
-    let mut c = Config::builder();
-    c.add_source(File::new("tests/Settings", FileFormat::Toml));
-    c.build().unwrap()
+    let mut c = Config::default();
+    c.merge(File::new("tests/Settings", FileFormat::Toml))
+        .unwrap();
+
+    c
 }
 
 #[test]

--- a/tests/legacy/merge.rs
+++ b/tests/legacy/merge.rs
@@ -1,0 +1,49 @@
+#![cfg(feature = "toml")]
+
+extern crate config;
+
+use self::config::*;
+
+fn make() -> Config {
+    let mut c = Config::default();
+    c.merge(File::new("tests/Settings", FileFormat::Toml))
+        .unwrap();
+
+    c.merge(File::new("tests/Settings-production", FileFormat::Toml))
+        .unwrap();
+
+    c
+}
+
+#[test]
+fn test_merge() {
+    let c = make();
+
+    assert_eq!(c.get("debug").ok(), Some(false));
+    assert_eq!(c.get("production").ok(), Some(true));
+    assert_eq!(
+        c.get("place.creator.name").ok(),
+        Some("Somebody New".to_string())
+    );
+    assert_eq!(c.get("place.rating").ok(), Some(4.9));
+}
+
+#[test]
+fn test_merge_whole_config() {
+    let mut c1 = Config::default();
+    let mut c2 = Config::default();
+
+    c1.set("x", 10).unwrap();
+    c2.set("y", 25).unwrap();
+
+    assert_eq!(c1.get("x").ok(), Some(10));
+    assert_eq!(c2.get::<()>("x").ok(), None);
+
+    assert_eq!(c2.get("y").ok(), Some(25));
+    assert_eq!(c1.get::<()>("y").ok(), None);
+
+    c1.merge(c2).unwrap();
+
+    assert_eq!(c1.get("x").ok(), Some(10));
+    assert_eq!(c1.get("y").ok(), Some(25));
+}

--- a/tests/legacy/mod.rs
+++ b/tests/legacy/mod.rs
@@ -1,0 +1,12 @@
+pub mod datetime;
+pub mod errors;
+pub mod file;
+pub mod file_hjson;
+pub mod file_ini;
+pub mod file_json;
+pub mod file_ron;
+pub mod file_toml;
+pub mod file_yaml;
+pub mod get;
+pub mod merge;
+pub mod set;

--- a/tests/legacy/set.rs
+++ b/tests/legacy/set.rs
@@ -1,0 +1,93 @@
+extern crate config;
+
+use self::config::*;
+
+#[test]
+fn test_set_scalar() {
+    let mut c = Config::default();
+
+    c.set("value", true).unwrap();
+
+    assert_eq!(c.get("value").ok(), Some(true));
+}
+
+#[cfg(feature = "toml")]
+#[test]
+fn test_set_scalar_default() {
+    let mut c = Config::default();
+
+    c.merge(File::new("tests/Settings", FileFormat::Toml))
+        .unwrap();
+
+    c.set_default("debug", false).unwrap();
+    c.set_default("staging", false).unwrap();
+
+    assert_eq!(c.get("debug").ok(), Some(true));
+    assert_eq!(c.get("staging").ok(), Some(false));
+}
+
+#[cfg(feature = "toml")]
+#[test]
+fn test_set_scalar_path() {
+    let mut c = Config::default();
+
+    c.set("first.second.third", true).unwrap();
+
+    assert_eq!(c.get("first.second.third").ok(), Some(true));
+
+    c.merge(File::new("tests/Settings", FileFormat::Toml))
+        .unwrap();
+
+    c.set_default("place.favorite", true).unwrap();
+    c.set_default("place.blocked", true).unwrap();
+
+    assert_eq!(c.get("place.favorite").ok(), Some(false));
+    assert_eq!(c.get("place.blocked").ok(), Some(true));
+}
+
+#[cfg(feature = "toml")]
+#[test]
+fn test_set_arr_path() {
+    let mut c = Config::default();
+
+    c.set("items[0].name", "Ivan").unwrap();
+
+    assert_eq!(c.get("items[0].name").ok(), Some("Ivan".to_string()));
+
+    c.set("data[0].things[1].name", "foo").unwrap();
+    c.set("data[0].things[1].value", 42).unwrap();
+    c.set("data[1]", 0).unwrap();
+
+    assert_eq!(
+        c.get("data[0].things[1].name").ok(),
+        Some("foo".to_string())
+    );
+    assert_eq!(c.get("data[0].things[1].value").ok(), Some(42));
+    assert_eq!(c.get("data[1]").ok(), Some(0));
+
+    c.merge(File::new("tests/Settings", FileFormat::Toml))
+        .unwrap();
+
+    c.set("items[0].name", "John").unwrap();
+
+    assert_eq!(c.get("items[0].name").ok(), Some("John".to_string()));
+
+    c.set("items[2]", "George").unwrap();
+
+    assert_eq!(c.get("items[2]").ok(), Some("George".to_string()));
+}
+
+#[cfg(feature = "toml")]
+#[test]
+fn test_set_capital() {
+    let mut c = Config::default();
+
+    c.set_default("this", false).unwrap();
+    c.set("ThAt", true).unwrap();
+    c.merge(File::from_str("{\"logLevel\": 5}", FileFormat::Json))
+        .unwrap();
+
+    assert_eq!(c.get("this").ok(), Some(false));
+    assert_eq!(c.get("ThAt").ok(), Some(true));
+    assert_eq!(c.get("logLevel").ok(), Some(5));
+}

--- a/tests/legacy_tests.rs
+++ b/tests/legacy_tests.rs
@@ -1,0 +1,5 @@
+#[allow(deprecated)]
+pub mod legacy;
+
+#[macro_use]
+extern crate serde_derive;

--- a/tests/merge.rs
+++ b/tests/merge.rs
@@ -5,11 +5,11 @@ extern crate config;
 use config::*;
 
 fn make() -> Config {
-    let mut builder = Config::builder();
-    builder
+    Config::builder()
         .add_source(File::new("tests/Settings", FileFormat::Toml))
-        .add_source(File::new("tests/Settings-production", FileFormat::Toml));
-    builder.build().unwrap()
+        .add_source(File::new("tests/Settings-production", FileFormat::Toml))
+        .build()
+        .unwrap()
 }
 
 #[test]
@@ -27,11 +27,8 @@ fn test_merge() {
 
 #[test]
 fn test_merge_whole_config() {
-    let mut builder1 = Config::builder();
-    let mut builder2 = Config::builder();
-
-    builder1.set_override("x", 10).unwrap();
-    builder2.set_override("y", 25).unwrap();
+    let builder1 = Config::builder().set_override("x", 10).unwrap();
+    let builder2 = Config::builder().set_override("y", 25).unwrap();
 
     let config1 = builder1.build_cloned().unwrap();
     let config2 = builder2.build_cloned().unwrap();
@@ -42,9 +39,7 @@ fn test_merge_whole_config() {
     assert_eq!(config2.get("y").ok(), Some(25));
     assert_eq!(config1.get::<()>("y").ok(), None);
 
-    builder1.add_source(config2);
-
-    let config3 = builder1.build().unwrap();
+    let config3 = builder1.add_source(config2).build().unwrap();
 
     assert_eq!(config3.get("x").ok(), Some(10));
     assert_eq!(config3.get("y").ok(), Some(25));

--- a/tests/set.rs
+++ b/tests/set.rs
@@ -4,11 +4,10 @@ use config::*;
 
 #[test]
 fn test_set_override_scalar() {
-    let mut builder = Config::builder();
-
-    builder.set_override("value", true).unwrap();
-
-    let config = builder.build().unwrap();
+    let config = Config::builder()
+        .set_override("value", true)
+        .and_then(|b| b.build())
+        .unwrap();
 
     assert_eq!(config.get("value").ok(), Some(true));
 }
@@ -16,16 +15,14 @@ fn test_set_override_scalar() {
 #[cfg(feature = "toml")]
 #[test]
 fn test_set_scalar_default() {
-    let mut builder = Config::builder();
-
-    builder
+    let config = Config::builder()
         .add_source(File::new("tests/Settings", FileFormat::Toml))
         .set_default("debug", false)
         .unwrap()
         .set_default("staging", false)
+        .unwrap()
+        .build()
         .unwrap();
-
-    let config = builder.build().unwrap();
 
     assert_eq!(config.get("debug").ok(), Some(true));
     assert_eq!(config.get("staging").ok(), Some(false));
@@ -34,18 +31,16 @@ fn test_set_scalar_default() {
 #[cfg(feature = "toml")]
 #[test]
 fn test_set_scalar_path() {
-    let mut builder = Config::builder();
-
-    builder
+    let config = Config::builder()
         .set_override("first.second.third", true)
         .unwrap()
         .add_source(File::new("tests/Settings", FileFormat::Toml))
         .set_default("place.favorite", true)
         .unwrap()
         .set_default("place.blocked", true)
+        .unwrap()
+        .build()
         .unwrap();
-
-    let config = builder.build().unwrap();
 
     assert_eq!(config.get("first.second.third").ok(), Some(true));
     assert_eq!(config.get("place.favorite").ok(), Some(false));
@@ -55,9 +50,7 @@ fn test_set_scalar_path() {
 #[cfg(feature = "toml")]
 #[test]
 fn test_set_arr_path() {
-    let mut builder = Config::builder();
-
-    builder
+    let config = Config::builder()
         .set_override("items[0].name", "Ivan")
         .unwrap()
         .set_override("data[0].things[1].name", "foo")
@@ -68,9 +61,9 @@ fn test_set_arr_path() {
         .unwrap()
         .add_source(File::new("tests/Settings", FileFormat::Toml))
         .set_override("items[2]", "George")
+        .unwrap()
+        .build()
         .unwrap();
-
-    let config = builder.build().unwrap();
 
     assert_eq!(config.get("items[0].name").ok(), Some("Ivan".to_string()));
     assert_eq!(
@@ -85,16 +78,14 @@ fn test_set_arr_path() {
 #[cfg(feature = "toml")]
 #[test]
 fn test_set_capital() {
-    let mut builder = Config::builder();
-
-    builder
+    let config = Config::builder()
         .set_default("this", false)
         .unwrap()
         .set_override("ThAt", true)
         .unwrap()
-        .add_source(File::from_str("{\"logLevel\": 5}", FileFormat::Json));
-
-    let config = builder.build().unwrap();
+        .add_source(File::from_str("{\"logLevel\": 5}", FileFormat::Json))
+        .build()
+        .unwrap();
 
     assert_eq!(config.get("this").ok(), Some(false));
     assert_eq!(config.get("ThAt").ok(), Some(true));


### PR DESCRIPTION
This is a draft PR to show an idea of how could ConfigBuilder look like.

It does not bring a lot of new functionality. It just splits Config that was a mutable configuration combined with a builder into two separate structs. It brings certain benefits:
* Config is no longer refreshed when a new source is added
* More from the clean code perspective, it lifts concepts of "mutable" and "frozen" config to type level, thus mitigating runtime errors. It is a clean code issue, as Config could not be frozen before as it was a dead private API.

Immutability is considered good programming practice, but not everyone might like it. I'd like to hear the opinions of users of the library - do you mutate config often after application initial bootstrap, do you consider such a mutability a needed feature?

I do not intend to push it in its current form, it is just to showcase an idea. To consider it mergeable discussion has to take place regarding few subjects:
* is it the correct way to go
* should old ways be deprecated as it is done now or should they be removed

In the current state there is a lot of deprecation warnings, so please do not mind them now and focus on more high-level aspects of this PR.

I attach a graph of the intended workflow so that it is easier to see the big picture.
![image](https://user-images.githubusercontent.com/32487860/113404027-d3f80380-93a7-11eb-9810-8e7eb98da92d.png)

