### PR TITLE
actions: Let test, fmt, clippy only run if check succeeded

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -29,6 +29,7 @@ jobs:
           command: check
 
   test:
+    needs: [check]
     name: Test Suite
     runs-on: ubuntu-latest
     strategy:
@@ -53,6 +54,7 @@ jobs:
           command: test
 
   fmt:
+    needs: [check]
     name: Rustfmt
     runs-on: ubuntu-latest
     strategy:
@@ -80,6 +82,7 @@ jobs:
           args: --all -- --check
 
   clippy:
+    needs: [check]
     name: Clippy
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
I learned this today, that actions can depend on eachother.

This is a small improvement to our CI setup, so that `cargo check` must succeed before `cargo test`, `cargo fmt -- --check` and `cargo clippy` are run.

Do we want this?