### PR TITLE
ValueKind is now public to users of the crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,3 +71,4 @@ pub use crate::error::ConfigError;
 pub use crate::file::{File, FileFormat, FileSourceFile, FileSourceString};
 pub use crate::source::Source;
 pub use crate::value::Value;
+pub use crate::value::ValueKind;

--- a/src/value.rs
+++ b/src/value.rs
@@ -7,6 +7,10 @@ use serde::de::{Deserialize, Deserializer, Visitor};
 use crate::error::*;
 
 /// Underlying kind of the configuration value.
+///
+/// Standard operations on a `Value` by users of this crate do not require
+/// knowledge of `ValueKind`. Introspection of underlying kind is only required
+/// when the configuration values are unstructured or do not have known types.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ValueKind {
     Nil,


### PR DESCRIPTION
`ValueKind` is now exposed publicly to users of this crate. This is not necessary for normal operations on `Value`, but can be useful for operations such as serializing configuration to another format, such as JSON.

This is related to issue #62 