### PR TITLE
Fix clippy: Do not borrow reference

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -281,7 +281,7 @@ impl<'de> de::EnumAccess<'de> for EnumAccess {
         let value = {
             let deserializer = match self.value.kind {
                 ValueKind::String(ref s) => self.variant_deserializer(s),
-                ValueKind::Table(ref t) => self.table_deserializer(&t),
+                ValueKind::Table(ref t) => self.table_deserializer(t),
                 _ => Err(self.structural_error()),
             }?;
             seed.deserialize(deserializer)?

--- a/src/file/format/json5.rs
+++ b/src/file/format/json5.rs
@@ -20,7 +20,7 @@ pub fn parse(
     uri: Option<&String>,
     text: &str,
 ) -> Result<HashMap<String, Value>, Box<dyn Error + Send + Sync>> {
-    match json5_rs::from_str::<Val>(&text)? {
+    match json5_rs::from_str::<Val>(text)? {
         Val::String(ref value) => Err(Unexpected::Str(value.clone())),
         Val::Integer(value) => Err(Unexpected::Integer(value)),
         Val::Float(value) => Err(Unexpected::Float(value)),

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -187,7 +187,7 @@ impl<'a> ser::Serializer for &'a mut ConfigSerializer {
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<Self::Ok> {
-        self.serialize_str(&variant)
+        self.serialize_str(variant)
     }
 
     fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
@@ -207,7 +207,7 @@ impl<'a> ser::Serializer for &'a mut ConfigSerializer {
     where
         T: ?Sized + ser::Serialize,
     {
-        self.push_key(&variant);
+        self.push_key(variant);
         value.serialize(&mut *self)?;
         self.pop_key();
         Ok(())
@@ -236,7 +236,7 @@ impl<'a> ser::Serializer for &'a mut ConfigSerializer {
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
-        self.push_key(&variant);
+        self.push_key(variant);
         Ok(self)
     }
 
@@ -255,7 +255,7 @@ impl<'a> ser::Serializer for &'a mut ConfigSerializer {
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        self.push_key(&variant);
+        self.push_key(variant);
         Ok(self)
     }
 }


### PR DESCRIPTION
Reported from nightly clippy, this borrowing of a reference is uneccessary.
