### PR TITLE
On nightly, ignore errors

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -24,6 +24,14 @@ jobs:
           override: true
 
       - name: Run cargo check
+        if: matrix.rust != 'nightly'
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+      - name: Run cargo check (nightly)
+        if: matrix.rust == 'nightly'
+        continue-on-error: true
         uses: actions-rs/cargo@v1
         with:
           command: check
@@ -49,6 +57,14 @@ jobs:
           override: true
 
       - name: Run cargo test
+        if: matrix.rust != 'nightly'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - name: Run cargo test (nightly)
+        if: matrix.rust == 'nightly'
+        continue-on-error: true
         uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
This changes the CI setup so that failures on nightly do not break the
CI jobs. This way we can see that nightly changes things but our build
doesn't break immediately.

Because we do not depend on nightly features, I guess this is a good
idea.