### PR TITLE
Update nom to v7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ preserve_order = ["indexmap", "toml/preserve_order", "serde_json/preserve_order"
 async-trait = "0.1.50"
 lazy_static = "1.0"
 serde = "1.0.8"
-nom = "6"
+nom = "7"
 
 toml = { version = "0.5", optional = true }
 serde_json = { version = "1.0.2", optional = true }


### PR DESCRIPTION
Hello,
I had an issue when building with `nigthly-2021-10-26` because of an outdated dependency of `nom` (`lexical-core`).
I updated `nom` to version `7` and now it builds.
I also ran `cargo test` and all the tests passed, so here's a PR if you're interested in the update.