### PR TITLE
chore: use pathdiff crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rust-ini = { version = "0.17", optional = true }
 ron = { version = "0.6", optional = true }
 json5_rs = { version = "0.3", optional = true, package = "json5" }
 indexmap = { version = "1.7.0", features = ["serde-1"], optional = true}
+pathdiff = "0.2"
 
 [dev-dependencies]
 serde_derive = "1.0.8"


### PR DESCRIPTION
The resource the link in that comment points to no longer exists. When finding the updated file, they are now using this crate instead

https://github.com/rust-lang/rust/blob/02913c078849f940371eb9930754f2b0f1bc9fad/compiler/rustc_codegen_ssa/src/back/rpath.rs#L96