### PR TITLE
Add #[must_use] annotations

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -181,6 +181,7 @@ impl ConfigBuilder<DefaultState> {
     /// Registers new [`Source`] in this builder.
     ///
     /// Calling this method does not invoke any I/O. [`Source`] is only saved in internal register for later use.
+    #[must_use]
     pub fn add_source<T>(mut self, source: T) -> Self
     where
         T: Source + Send + Sync + 'static,
@@ -270,6 +271,7 @@ impl ConfigBuilder<AsyncState> {
     /// Registers new [`Source`] in this builder.
     ///
     /// Calling this method does not invoke any I/O. [`Source`] is only saved in internal register for later use.
+    #[must_use]
     pub fn add_source<T>(mut self, source: T) -> ConfigBuilder<AsyncState>
     where
         T: Source + Send + Sync + 'static,
@@ -281,6 +283,7 @@ impl ConfigBuilder<AsyncState> {
     /// Registers new [`AsyncSource`] in this builder.
     ///
     /// Calling this method does not invoke any I/O. [`AsyncSource`] is only saved in internal register for later use.
+    #[must_use]
     pub fn add_async_source<T>(mut self, source: T) -> ConfigBuilder<AsyncState>
     where
         T: AsyncSource + Send + Sync + 'static,

--- a/src/env.rs
+++ b/src/env.rs
@@ -77,16 +77,19 @@ impl Environment {
         }
     }
 
+    #[must_use]
     pub fn prefix(mut self, s: &str) -> Self {
         self.prefix = Some(s.into());
         self
     }
 
+    #[must_use]
     pub fn separator(mut self, s: &str) -> Self {
         self.separator = Some(s.into());
         self
     }
 
+    #[must_use]
     pub fn ignore_empty(mut self, ignore: bool) -> Self {
         self.ignore_empty = ignore;
         self
@@ -94,11 +97,13 @@ impl Environment {
 
     /// Note: enabling `try_parsing` can reduce performance it will try and parse
     /// each environment variable 3 times (bool, i64, f64)
+    #[must_use]
     pub fn try_parsing(mut self, try_parsing: bool) -> Self {
         self.try_parsing = try_parsing;
         self
     }
 
+    #[must_use]
     pub fn source(mut self, source: Option<Map<String, String>>) -> Self {
         self.source = source;
         self

--- a/src/error.rs
+++ b/src/error.rs
@@ -114,6 +114,7 @@ impl ConfigError {
 
     // FIXME: pub(crate)
     #[doc(hidden)]
+    #[must_use]
     pub fn extend_with_key(self, key: &str) -> Self {
         match self {
             ConfigError::Type {
@@ -132,6 +133,7 @@ impl ConfigError {
         }
     }
 
+    #[must_use]
     fn prepend(self, segment: String, add_dot: bool) -> Self {
         let concat = |key: Option<String>| {
             let key = key.unwrap_or_else(String::new);
@@ -159,10 +161,12 @@ impl ConfigError {
         }
     }
 
+    #[must_use]
     pub(crate) fn prepend_key(self, key: String) -> Self {
         self.prepend(key, true)
     }
 
+    #[must_use]
     pub(crate) fn prepend_index(self, idx: usize) -> Self {
         self.prepend(format!("[{}]", idx), false)
     }

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -101,11 +101,13 @@ where
     F: FileStoredFormat + 'static,
     T: FileSource<F>,
 {
+    #[must_use]
     pub fn format(mut self, format: F) -> Self {
         self.format = Some(format);
         self
     }
 
+    #[must_use]
     pub fn required(mut self, required: bool) -> Self {
         self.required = required;
         self


### PR DESCRIPTION
Clippy nightly fails the checks because it wants us to have a
`#[must_use]` annotation on functions that return `Self`.

So we add these annotations with this patch.

---

@danieleades I'm not sure whether you included this in your patchsets somewhere... :laughing: 