### PR TITLE
move 'must_use' attribute to struct for 'builder' types

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -87,6 +87,7 @@ use crate::{config::Config, path::Expression, source::Source, value::Value};
 /// let mut builder = ConfigBuilder::<DefaultState>::default();
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use]
 pub struct ConfigBuilder<St: BuilderState> {
     defaults: Map<Expression, Value>,
     overrides: Map<Expression, Value>,
@@ -201,7 +202,6 @@ impl ConfigBuilder<DefaultState> {
     /// Registers new [`Source`] in this builder.
     ///
     /// Calling this method does not invoke any I/O. [`Source`] is only saved in internal register for later use.
-    #[must_use]
     pub fn add_source<T>(mut self, source: T) -> Self
     where
         T: Source + Send + Sync + 'static,
@@ -291,7 +291,6 @@ impl ConfigBuilder<AsyncState> {
     /// Registers new [`Source`] in this builder.
     ///
     /// Calling this method does not invoke any I/O. [`Source`] is only saved in internal register for later use.
-    #[must_use]
     pub fn add_source<T>(mut self, source: T) -> Self
     where
         T: Source + Send + Sync + 'static,
@@ -303,7 +302,6 @@ impl ConfigBuilder<AsyncState> {
     /// Registers new [`AsyncSource`] in this builder.
     ///
     /// Calling this method does not invoke any I/O. [`AsyncSource`] is only saved in internal register for later use.
-    #[must_use]
     pub fn add_async_source<T>(mut self, source: T) -> Self
     where
         T: AsyncSource + Send + Sync + 'static,

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -20,6 +20,7 @@ pub use self::source::string::FileSourceString;
 ///
 /// It supports optional automatic file format discovery.
 #[derive(Clone, Debug)]
+#[must_use]
 pub struct File<T, F> {
     source: T,
 
@@ -101,13 +102,11 @@ where
     F: FileStoredFormat + 'static,
     T: FileSource<F>,
 {
-    #[must_use]
     pub fn format(mut self, format: F) -> Self {
         self.format = Some(format);
         self
     }
 
-    #[must_use]
     pub fn required(mut self, required: bool) -> Self {
         self.required = required;
         self


### PR DESCRIPTION
note that this fails currently due to an upstream false positive in clippy.