### PR TITLE
Add cron job

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,61 @@
+name: Cron
+
+on:
+  schedule:
+    # every friday at 10:00 am
+    - cron: '0 10 * * 5'
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.56.1
+          - stable
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          minimal: true
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all --all-features --examples
+
+  clippy:
+    needs: [check]
+    name: Clippy
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          minimal: true
+          override: true
+          components: clippy
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets --all-features -- -D warnings
+


### PR DESCRIPTION
This patch adds a cron job to run cargo-check and cargo-clippy every
week, so that we are notified if the builds start failing because of
updated rustc/clippy versions if we did not have any commits in that
time.

---

Maybe someone wants to comment, so I'll wait with merging for a bit.