### PR TITLE
chore: update dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,30 +23,30 @@ json5 = ["json5_rs"]
 preserve_order = ["indexmap", "toml/preserve_order", "serde_json/preserve_order", "ron/indexmap"]
 
 [dependencies]
-async-trait = "0.1"
-lazy_static = "1.4"
-serde = "1.0"
-nom = "7"
+async-trait = "0.1.52"
+lazy_static = "1.4.0"
+serde = "1.0.136"
+nom = "7.1.0"
 
-toml = { version = "0.5", optional = true }
-serde_json = { version = "1.0", optional = true }
-yaml-rust = { version = "0.4", optional = true }
-rust-ini = { version = "0.18", optional = true }
-ron = { version = "0.7", optional = true }
-json5_rs = { version = "0.4", optional = true, package = "json5" }
-indexmap = { version = "1.8", features = ["serde-1"], optional = true}
-pathdiff = "0.2"
+toml = { version = "0.5.8", optional = true }
+serde_json = { version = "1.0.79", optional = true }
+yaml-rust = { version = "0.4.5", optional = true }
+rust-ini = { version = "0.18.0", optional = true }
+ron = { version = "0.7.0", optional = true }
+json5_rs = { version = "0.4.1", optional = true, package = "json5" }
+indexmap = { version = "1.8.0", features = ["serde-1"], optional = true}
+pathdiff = "0.2.1"
 
 [dev-dependencies]
-serde_derive = "1.0.8"
-float-cmp = "0.9"
-chrono = { version = "0.4", features = ["serde"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util", "time"]}
+serde_derive = "1.0.136"
+float-cmp = "0.9.0"
+chrono = { version = "0.4.19", features = ["serde"] }
+tokio = { version = "1.17.0", features = ["rt-multi-thread", "macros", "fs", "io-util", "time"]}
 warp = "0.3.2"
-futures = "0.3.15"
+futures = "0.3.21"
 reqwest = "0.11.9"
 
-serde = "1.0"
-glob = "0.3"
-lazy_static = "1"
+serde = "1.0.136"
+glob = "0.3.0"
+lazy_static = "1.4.0"
 notify = "^4.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,18 +23,18 @@ json5 = ["json5_rs"]
 preserve_order = ["indexmap", "toml/preserve_order", "serde_json/preserve_order", "ron/indexmap"]
 
 [dependencies]
-async-trait = "0.1.50"
-lazy_static = "1.0"
-serde = "1.0.8"
+async-trait = "0.1"
+lazy_static = "1.4"
+serde = "1.0"
 nom = "7"
 
 toml = { version = "0.5", optional = true }
-serde_json = { version = "1.0.2", optional = true }
+serde_json = { version = "1.0", optional = true }
 yaml-rust = { version = "0.4", optional = true }
 rust-ini = { version = "0.18", optional = true }
 ron = { version = "0.7", optional = true }
 json5_rs = { version = "0.4", optional = true, package = "json5" }
-indexmap = { version = "1.7.0", features = ["serde-1"], optional = true}
+indexmap = { version = "1.8", features = ["serde-1"], optional = true}
 pathdiff = "0.2"
 
 [dev-dependencies]
@@ -42,9 +42,9 @@ serde_derive = "1.0.8"
 float-cmp = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util", "time"]}
-warp = "=0.3.1"
+warp = "0.3.2"
 futures = "0.3.15"
-reqwest = "=0.11.9" # version is forced to allow examples compile on rust 1.46, remove "=" as soon as possible
+reqwest = "0.11.9"
 
 serde = "1.0"
 glob = "0.3"


### PR DESCRIPTION
This commit updates few dependencies to their latest version, and remove the Z version (in the X.Y.Z nomenclature) to always use the latest bug fix version available. And reduce for an application using config-rs to not build two times a dependency (I mean in two different version).

Plus, I remove a comment since the upgrade to Rust 1.49 here (https://github.com/mehcode/config-rs/commit/a7c6cc7daab224ff653d2b908ed9590ce3f6934b)

If I did something wrong, just let me know.