### PR TITLE
chore: add the possibility to keep the prefix from env var.

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -37,6 +37,9 @@ pub struct Environment {
     /// Parses booleans, integers and floats if they're detected (can be safely parsed).
     try_parsing: bool,
 
+    // Preserve the prefix while parsing
+    keep_prefix: bool,
+
     /// Alternate source for the environment. This can be used when you want to test your own code
     /// using this source, without the need to change the actual system environment variables.
     ///
@@ -136,6 +139,11 @@ impl Environment {
         self
     }
 
+    pub fn keep_prefix(mut self, keep: bool) -> Self {
+        self.keep_prefix = keep;
+        self
+    }
+
     pub fn source(mut self, source: Option<Map<String, String>>) -> Self {
         self.source = source;
         self
@@ -175,8 +183,10 @@ impl Source for Environment {
             // Check for prefix
             if let Some(ref prefix_pattern) = prefix_pattern {
                 if key.starts_with(prefix_pattern) {
-                    // Remove this prefix from the key
-                    key = key[prefix_pattern.len()..].to_string();
+                    if !self.keep_prefix {
+                        // Remove this prefix from the key
+                        key = key[prefix_pattern.len()..].to_string();
+                    }
                 } else {
                     // Skip this key
                     return;

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -75,6 +75,27 @@ fn test_empty_value_is_ignored() {
 }
 
 #[test]
+fn test_keep_prefix() {
+    env::set_var("C_A_B", "");
+
+    // Do not keep the prefix
+    let environment = Environment::with_prefix("C");
+
+    assert!(environment.collect().unwrap().contains_key("a_b"));
+
+    let environment = Environment::with_prefix("C").keep_prefix(false);
+
+    assert!(environment.collect().unwrap().contains_key("a_b"));
+
+    // Keep the prefix
+    let environment = Environment::with_prefix("C").keep_prefix(true);
+
+    assert!(environment.collect().unwrap().contains_key("c_a_b"));
+
+    env::remove_var("C_A_B");
+}
+
+#[test]
 fn test_custom_separator_behavior() {
     env::set_var("C.B.A", "abc");
 


### PR DESCRIPTION
Resolve the issue #290

I wanted to work on this feature. Since it has a minimal impact on the overall library. I found it quite interesting for few use cases. But let me know if you would prefer to do it in an other way. 