### PR TITLE
Update reqwest dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util", "time"]}
 warp = "=0.3.1"
 futures = "0.3.15"
-reqwest = "=0.11.9" # version is forced to allow examples compile on rust 1.46, remove "=" as soon as possible
+reqwest = "0.11.10"
 
 serde = "1.0"
 glob = "0.3"


### PR DESCRIPTION
MSRV is 1.49, so we do not have to pin this dependency anymore.

Closes #300 