### PR TITLE
Update MSRV

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.49.0
+          - 1.56.0
           - stable
           - beta
           - nightly
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.49.0
+          - 1.56.0
           - stable
           - beta
           - nightly
@@ -61,14 +61,14 @@ jobs:
           override: true
 
       - name: Run cargo test
-        if: matrix.rust != 'nightly' && matrix.rust != '1.49.0'
+        if: matrix.rust != 'nightly' && matrix.rust != '1.56.0'
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features
 
       - name: Run cargo test (nightly)
-        if: matrix.rust == '1.49.0'
+        if: matrix.rust == '1.56.0'
         continue-on-error: true
         uses: actions-rs/cargo@v1
         with:
@@ -145,7 +145,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.49.0
+          - 1.56.0
           - stable
 
     steps:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ more usage information.
 
 ## MSRV
 
-We currently support Rust 1.49.0 and newer.
+We currently support Rust 1.56.0 and newer.
 
 
 ## License


### PR DESCRIPTION
One of our (transitive?) dependencies requires us to compile with a
compiler that supports rust 2021, so we update the MSRV as well.
