### PR TITLE
fix: dot in config name

### DIFF
--- a/src/file/source/file.rs
+++ b/src/file/source/file.rs
@@ -27,7 +27,7 @@ impl FileSourceFile {
     where
         F: FileStoredFormat + Format + 'static,
     {
-        let mut filename = if self.name.is_absolute() {
+        let filename = if self.name.is_absolute() {
             self.name.clone()
         } else {
             env::current_dir()?.as_path().join(&self.name)
@@ -59,6 +59,9 @@ impl FileSourceFile {
                 )))
             };
         }
+        // Adding a dummy extension will make sure we will not override secondary extensions, i.e. "file.local"
+        // This will make the following set_extension function calls to append the extension.
+        let mut filename = add_dummy_extension(filename);
 
         match format_hint {
             Some(format) => {
@@ -120,4 +123,19 @@ where
             format,
         })
     }
+}
+
+fn add_dummy_extension(mut filename: PathBuf) -> PathBuf {
+    match filename.extension() {
+        Some(extension) => {
+            let mut ext = extension.to_os_string();
+            ext.push(".");
+            ext.push("dummy");
+            filename.set_extension(ext);
+        }
+        None => {
+            filename.set_extension("dummy");
+        }
+    }
+    filename
 }

--- a/tests/Settings2.default.ini
+++ b/tests/Settings2.default.ini
@@ -1,0 +1,9 @@
+debug = true
+production = false
+[place]
+name = Torre di Pisa
+longitude = 43.7224985
+latitude = 10.3970522
+favorite = false
+reviews = 3866
+rating = 4.5

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -58,3 +58,13 @@ fn test_file_ext() {
     assert_eq!(c.get("debug").ok(), Some(true));
     assert_eq!(c.get("production").ok(), Some(false));
 }
+#[test]
+fn test_file_second_ext() {
+    let c = Config::builder()
+        .add_source(File::with_name("tests/Settings2.default"))
+        .build()
+        .unwrap();
+
+    assert_eq!(c.get("debug").ok(), Some(true));
+    assert_eq!(c.get("production").ok(), Some(false));
+}


### PR DESCRIPTION
Rust std `set_extension` is either add an extension if none exists, or
edit the current one if such exists.

This caused a mishandling when user is using a name with a dot,
part of the name was treated as an extension, and be overwritten by
the different format extensions.

So manually *adding* a new dummy extension will cause the current code,
to behave as expected, since it will always overwrite the new dummy
extension and not part of the name.