### PR TITLE
errors: clarify names of integer types

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -23,10 +23,10 @@ impl fmt::Display for Unexpected {
     fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
         match *self {
             Unexpected::Bool(b) => write!(f, "boolean `{}`", b),
-            Unexpected::I64(i) => write!(f, "integer 64 bit `{}`", i),
-            Unexpected::I128(i) => write!(f, "integer 128 bit `{}`", i),
-            Unexpected::U64(i) => write!(f, "unsigned integer 64 bit `{}`", i),
-            Unexpected::U128(i) => write!(f, "unsigned integer 128 bit `{}`", i),
+            Unexpected::I64(i) => write!(f, "64-bit integer `{}`", i),
+            Unexpected::I128(i) => write!(f, "128-bit integer `{}`", i),
+            Unexpected::U64(i) => write!(f, "64-bit unsigned integer `{}`", i),
+            Unexpected::U128(i) => write!(f, "128-bit unsigned integer `{}`", i),
             Unexpected::Float(v) => write!(f, "floating point `{}`", v),
             Unexpected::Str(ref s) => write!(f, "string {:?}", s),
             Unexpected::Unit => write!(f, "unit value"),


### PR DESCRIPTION
I got this error message:

```
invalid type: integer 64 bit `5`, expected an array
```

It took me a while to figure out that it wasn't talking about bit
number 5 of the number 64, but the 64-bit number `5`. I think it will
be clearer like this:

```
invalid type: 64-bit integer `5`, expected an array
```

So that's what this patch implements.