### PR TITLE
Fix json5 test: Remove artifact character

### DIFF
--- a/tests/file.rs
+++ b/tests/file.rs
@@ -8,7 +8,7 @@ fn test_file_not_required() {
         .add_source(File::new("tests/NoSettings", FileFormat::Yaml).required(false))
         .build();
 
-    assert!(res.is_ok());
+    assert!(res.unwrap());
 }
 
 #[test]

--- a/tests/file_json5.rs
+++ b/tests/file_json5.rs
@@ -84,7 +84,7 @@ fn test_error_parse() {
     assert_eq!(
         res.unwrap_err().to_string(),
         format!(
-            " --> 2:7\n  |\n2 |   ok: true␊\n  |       ^---\n  |\n  = expected null in {}",
+            " --> 2:7\n  |\n2 |   ok: true\n  |       ^---\n  |\n  = expected null in {}",
             path_with_extension.display()
         )
     );


### PR DESCRIPTION
I am not sure what happened that these tests suddenly fail, or where the
artifact comes from...

@up9cloud you implemented this two years ago... maybe you have at least an idea? :thinking: 