### PR TITLE
Run clippy only on MSRV

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -111,12 +111,6 @@ jobs:
     needs: [check]
     name: Clippy
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - stable
-          - beta
-          - nightly
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3.0.2
@@ -124,7 +118,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: 1.56.1
           override: true
           components: clippy
 

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -191,7 +191,9 @@ fn test_parse_float() {
 
         // can't use `matches!` because of float value
         match config {
-            TestFloatEnum::Float(TestFloat { float_val }) => assert_eq!(float_val, 42.3),
+            TestFloatEnum::Float(TestFloat { float_val }) => {
+                assert!(float_cmp::approx_eq!(f64, float_val, 42.3))
+            }
         }
     })
 }

--- a/tests/file_json5.rs
+++ b/tests/file_json5.rs
@@ -84,7 +84,7 @@ fn test_error_parse() {
     assert_eq!(
         res.unwrap_err().to_string(),
         format!(
-            " --> 2:7\n  |\n2 |   ok: true␊\n  |       ^---\n  |\n  = expected null in {}",
+            " --> 2:7\n  |\n2 |   ok: true\n  |       ^---\n  |\n  = expected null in {}",
             path_with_extension.display()
         )
     );


### PR DESCRIPTION
This patch reverts the matrix for the clippy job to only run clippy on
our MSRV instead of stable, beta and nightly.

The recurring issue with this was that lints started failing in PRs that
couldn't have been fixed in master yet, because master was never tested
with a clippy that new (in case of nightly).

1.56.1 is good enough for now.

---

Closes #361