### PR TITLE
0.13.x: Backport #362

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -114,12 +114,6 @@ jobs:
     needs: [check]
     name: Clippy
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - stable
-          - beta
-          - nightly
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -127,8 +121,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.rust }}
-          minimal: true
+          toolchain: 1.56.1
           override: true
           components: clippy
 

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -191,7 +191,9 @@ fn test_parse_float() {
 
         // can't use `matches!` because of float value
         match config {
-            TestFloatEnum::Float(TestFloat { float_val }) => assert_eq!(float_val, 42.3),
+            TestFloatEnum::Float(TestFloat { float_val }) => {
+                assert!(float_cmp::approx_eq!(f64, float_val, 42.3))
+            }
         }
     })
 }


### PR DESCRIPTION
Port #362 ("Run clippy only on MSRV") to the `release-0.13.x` branch.

---

With the `0.13.2` release, clippy fails because of this. Port back the changes from #362 so that in our next patch release (if it happens), this does not break again.