### PR TITLE
Add clone to builder state types

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -98,7 +98,7 @@ pub struct ConfigBuilder<St: BuilderState> {
 pub trait BuilderState {}
 
 /// Represents data specific to builder in default, sychronous state, without support for async.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct DefaultState {
     sources: Vec<Box<dyn Source + Send + Sync>>,
 }
@@ -124,7 +124,7 @@ pub struct DefaultState {
 pub struct AsyncConfigBuilder {}
 
 /// Represents data specific to builder in asychronous state, with support for async.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct AsyncState {
     sources: Vec<SourceType>,
 }


### PR DESCRIPTION
This PR is to add `Clone` impl to both `DefaultState` and `AsyncState`. This allows `ConfigBuilder` to be fully clonable. My goal is to make [bevy plugin](https://bevyengine.org/learn/book/getting-started/plugins/) that inserts `ConfigBuilder` as [resource](https://bevyengine.org/learn/book/getting-started/resources/) so that developers can query them from [systems](https://bevy-cheatbook.github.io/programming/systems.html) and modify (e.g. configure additional source file etc.). 

I'm not 100% sure this is a right approach but it satisfied my use case for now. Let me know if there's other way to make it work.

## Example
- [PoC PR](https://github.com/diptools/dip/pull/117)
- [code](https://github.com/diptools/dip/blob/feat/%23115-config-resource/examples/cli/config/main.rs)

Without clone
```sh
🦄  cargo run --example cli_config
   Compiling dip v0.1.0 (/Users/js/projects/github.com/JunichiSugiura/dip)
error[E0507]: cannot move out of dereference of `dip::prelude::ResMut<'_, ConfigBuilder<DefaultState>>`
  --> examples/cli/config/main.rs:17:16
   |
17 |     *builder = builder.add_source(File::with_name("examples/cli/config/config/development"));
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ move occurs because value has type `ConfigBuilder<DefaultState>`, which does not implement the `Copy` trait

```