### PR TITLE
env: add a 'translate_key' field to ease dealing with kebab-case

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ mod value;
 
 pub use crate::builder::{AsyncConfigBuilder, ConfigBuilder};
 pub use crate::config::Config;
-pub use crate::env::Environment;
+pub use crate::env::{TranslationType, Environment};
 pub use crate::error::ConfigError;
 pub use crate::file::{File, FileFormat, FileSourceFile, FileSourceString, FileStoredFormat};
 pub use crate::format::Format;


### PR DESCRIPTION
This allows usage of `kebab-case` attribute in serde, allowing to mapping unambiguously into a config value given a multiple character separator.

    let environment = Environment::default()
        .prefix("PREFIX")
        .translate_key(TranslationType::Kebab)
        .separator("__");