### PR TITLE
Backport 379: Add clone trait to builder state

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -97,7 +97,7 @@ pub struct ConfigBuilder<St: BuilderState> {
 pub trait BuilderState {}
 
 /// Represents data specific to builder in default, sychronous state, without support for async.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct DefaultState {
     sources: Vec<Box<dyn Source + Send + Sync>>,
 }
@@ -123,7 +123,7 @@ pub struct DefaultState {
 pub struct AsyncConfigBuilder {}
 
 /// Represents data specific to builder in asychronous state, with support for async.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct AsyncState {
     sources: Vec<SourceType>,
 }


### PR DESCRIPTION
(cherry picked from commit 02c80a5c5a68022bd2d9eee7a67acff02062abb0)