### PR TITLE
Update MSRV: 1.56.0 -> 1.59.0

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0
+          - 1.59.0
           - stable
           - beta
           - nightly
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0
+          - 1.59.0
           - stable
           - beta
           - nightly
@@ -61,14 +61,14 @@ jobs:
           override: true
 
       - name: Run cargo test
-        if: matrix.rust != 'nightly' && matrix.rust != '1.56.0'
+        if: matrix.rust != 'nightly' && matrix.rust != '1.59.0'
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features
 
       - name: Run cargo test (nightly)
-        if: matrix.rust == '1.56.0'
+        if: matrix.rust == '1.59.0'
         continue-on-error: true
         uses: actions-rs/cargo@v1
         with:
@@ -121,7 +121,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.56.1
+          toolchain: 1.59.0
           override: true
           components: clippy
 
@@ -138,7 +138,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0
+          - 1.59.0
           - stable
 
     steps:

--- a/tests/datetime.rs
+++ b/tests/datetime.rs
@@ -86,25 +86,25 @@ fn test_datetime() {
     // JSON
     let date: DateTime<Utc> = s.get("json_datetime").unwrap();
 
-    assert_eq!(date, Utc.ymd(2017, 5, 10).and_hms(2, 14, 53));
+    assert_eq!(date, Utc.with_ymd_and_hms(2017, 5, 10, 2, 14, 53).unwrap());
 
     // TOML
     let date: DateTime<Utc> = s.get("toml_datetime").unwrap();
 
-    assert_eq!(date, Utc.ymd(2017, 5, 11).and_hms(14, 55, 15));
+    assert_eq!(date, Utc.with_ymd_and_hms(2017, 5, 11, 14, 55, 15).unwrap());
 
     // YAML
     let date: DateTime<Utc> = s.get("yaml_datetime").unwrap();
 
-    assert_eq!(date, Utc.ymd(2017, 6, 12).and_hms(10, 58, 30));
+    assert_eq!(date, Utc.with_ymd_and_hms(2017, 6, 12, 10, 58, 30).unwrap());
 
     // INI
     let date: DateTime<Utc> = s.get("ini_datetime").unwrap();
 
-    assert_eq!(date, Utc.ymd(2017, 5, 10).and_hms(2, 14, 53));
+    assert_eq!(date, Utc.with_ymd_and_hms(2017, 5, 10, 2, 14, 53).unwrap());
 
     // RON
     let date: DateTime<Utc> = s.get("ron_datetime").unwrap();
 
-    assert_eq!(date, Utc.ymd(2021, 4, 19).and_hms(11, 33, 2));
+    assert_eq!(date, Utc.with_ymd_and_hms(2021, 4, 19, 11, 33, 2).unwrap());
 }


### PR DESCRIPTION
Because a dependency requires 1.59.0 as MSRV, we must update it for the 0.13.3 patch release, unfortunately.