### PR TITLE
Fix clippy: Remove unnecessary cast

### DIFF
--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -163,8 +163,7 @@ impl Expression {
                             let index = sindex_to_uindex(index, array.len());
 
                             if index >= array.len() {
-                                array
-                                    .resize((index + 1) as usize, Value::new(None, ValueKind::Nil));
+                                array.resize(index + 1, Value::new(None, ValueKind::Nil));
                             }
 
                             Some(&mut array[index])
@@ -238,7 +237,7 @@ impl Expression {
                     if let ValueKind::Array(ref mut array) = parent.kind {
                         let uindex = sindex_to_uindex(index, array.len());
                         if uindex >= array.len() {
-                            array.resize((uindex + 1) as usize, Value::new(None, ValueKind::Nil));
+                            array.resize(uindex + 1, Value::new(None, ValueKind::Nil));
                         }
 
                         array[uindex] = value;


### PR DESCRIPTION
This removes an unnecessary cast as reported by the clippy cron job.