### PR TITLE
Update MSRV: 1.59.0 -> 1.60.0

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.59.0
+          - 1.60.0
           - stable
           - beta
           - nightly
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.59.0
+          - 1.60.0
           - stable
           - beta
           - nightly
@@ -57,7 +57,7 @@ jobs:
         run: cargo test --all-features
 
       - name: Run cargo test (nightly)
-        if: matrix.rust == '1.59.0'
+        if: matrix.rust == '1.60.0'
         continue-on-error: true
         run: cargo test --tests --all-features
 
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@1.59.0
+        uses: dtolnay/rust-toolchain@1.60.0
         with:
           components: clippy
 
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.59.0
+          - 1.60.0
           - stable
 
     steps:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ more usage information.
 
 ## MSRV
 
-We currently support Rust 1.59.0 and newer.
+We currently support Rust 1.60.0 and newer.
 
 
 ## License


### PR DESCRIPTION
The is necessary because if the "toml" dependency is updated to 0.6.0, it requires 1.60.0 as MSRV.

Required for #419 