### PR TITLE
Update MSRV: 1.60.0 -> 1.64.0

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0
+          - 1.64.0
           - stable
 
     steps:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0
+          - 1.64.0
           - stable
           - beta
           - nightly
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0
+          - 1.64.0
           - stable
           - beta
           - nightly
@@ -57,7 +57,7 @@ jobs:
         run: cargo test --all-features
 
       - name: Run cargo test (nightly)
-        if: matrix.rust == '1.60.0'
+        if: matrix.rust == '1.64.0'
         continue-on-error: true
         run: cargo test --tests --all-features
 
@@ -95,7 +95,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0
+          - 1.64.0
           - stable
     steps:
       - name: Checkout sources
@@ -117,7 +117,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0
+          - 1.64.0
           - stable
 
     steps:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ more usage information.
 
 ## MSRV
 
-We currently support Rust 1.60.0 and newer.
+We currently support Rust 1.64.0 and newer.
 
 
 ## License


### PR DESCRIPTION
We depend on temp_env in our tests, which got an update that bumps its own MSRV to 1.64.0.
Thus, we need to update to 1.64.0 or pin temp_env to an older version. We opt for the former.