### PR TITLE
Use weak features for preserve_order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ yaml = ["yaml-rust"]
 ini = ["rust-ini"]
 json5 = ["json5_rs", "serde/derive"]
 convert-case = ["convert_case"]
-preserve_order = ["indexmap", "toml/preserve_order", "serde_json/preserve_order", "ron/indexmap"]
+preserve_order = ["indexmap", "toml?/preserve_order", "serde_json?/preserve_order", "ron?/indexmap"]
 async = ["async-trait"]
 
 [dependencies]


### PR DESCRIPTION
Currently, `preserve_order` causes the toml, serde_json and ron dependencies to be enabled. This can be avoided by using cargo's support for [weak features].

[weak features]:
https://rust-lang.github.io/rfcs/3143-cargo-weak-namespaced-features.html

Weak features were stabilized in Rust 1.60 so there are no MSRV concerns.

I think this probably is a breaking change since it's possible some downstream users weren't enabling support explicitly.