### PR TITLE
Add test for empty inner object

### DIFF
--- a/tests/empty.rs
+++ b/tests/empty.rs
@@ -18,3 +18,25 @@ fn empty_deserializes() {
     assert_eq!(s.foo, 0);
     assert_eq!(s.bar, 0);
 }
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct A {
+    b: Option<B>,
+}
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct B {}
+
+#[test]
+fn empty_inner_obj() {
+    let a = A {
+        b: Some(B {})
+    };
+
+    let de_from_default_object: A = Config::builder()
+        .add_source(Config::try_from(&a).unwrap())
+        .build()
+        .unwrap()
+        .try_deserialize()
+        .unwrap();
+    assert_eq!(a, de_from_default_object); // Failed
+}


### PR DESCRIPTION
So far this only adds a test for an empty inner object as reported in #461.

If someone wants to help solving that issue, you're very much welcome.
