### PR TITLE
chore: Use a common method in parsers to check root is a table

### DIFF
--- a/src/file/format/json.rs
+++ b/src/file/format/json.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 
+use crate::format;
 use crate::map::Map;
 use crate::value::{Value, ValueKind};
 
@@ -8,13 +9,8 @@ pub fn parse(
     text: &str,
 ) -> Result<Map<String, Value>, Box<dyn Error + Send + Sync>> {
     // Parse a JSON object value from the text
-    // TODO: Have a proper error fire if the root of a file is ever not a Table
     let value = from_json_value(uri, &serde_json::from_str(text)?);
-    match value.kind {
-        ValueKind::Table(map) => Ok(map),
-
-        _ => Ok(Map::new()),
-    }
+    format::extract_root_table(uri, value)
 }
 
 fn from_json_value(uri: Option<&String>, value: &serde_json::Value) -> Value {

--- a/src/file/format/json5.rs
+++ b/src/file/format/json5.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use crate::error::{ConfigError, Unexpected};
+use crate::format;
 use crate::map::Map;
 use crate::value::{Value, ValueKind};
 
@@ -20,20 +20,8 @@ pub fn parse(
     uri: Option<&String>,
     text: &str,
 ) -> Result<Map<String, Value>, Box<dyn Error + Send + Sync>> {
-    match json5_rs::from_str::<Val>(text)? {
-        Val::String(ref value) => Err(Unexpected::Str(value.clone())),
-        Val::Integer(value) => Err(Unexpected::I64(value)),
-        Val::Float(value) => Err(Unexpected::Float(value)),
-        Val::Boolean(value) => Err(Unexpected::Bool(value)),
-        Val::Array(_) => Err(Unexpected::Seq),
-        Val::Null => Err(Unexpected::Unit),
-        Val::Object(o) => match from_json5_value(uri, Val::Object(o)).kind {
-            ValueKind::Table(map) => Ok(map),
-            _ => Ok(Map::new()),
-        },
-    }
-    .map_err(|err| ConfigError::invalid_root(uri, err))
-    .map_err(|err| Box::new(err) as Box<dyn Error + Send + Sync>)
+    let value = from_json5_value(uri, json5_rs::from_str::<Val>(text)?);
+    format::extract_root_table(uri, value)
 }
 
 fn from_json5_value(uri: Option<&String>, value: Val) -> Value {

--- a/src/file/format/ron.rs
+++ b/src/file/format/ron.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 
+use crate::format;
 use crate::map::Map;
 use crate::value::{Value, ValueKind};
 
@@ -8,11 +9,7 @@ pub fn parse(
     text: &str,
 ) -> Result<Map<String, Value>, Box<dyn Error + Send + Sync>> {
     let value = from_ron_value(uri, ron::from_str(text)?)?;
-    match value.kind {
-        ValueKind::Table(map) => Ok(map),
-
-        _ => Ok(Map::new()),
-    }
+    format::extract_root_table(uri, value)
 }
 
 fn from_ron_value(

--- a/src/file/format/toml.rs
+++ b/src/file/format/toml.rs
@@ -1,20 +1,16 @@
 use std::error::Error;
 
+use crate::format;
 use crate::map::Map;
-use crate::value::{Value, ValueKind};
+use crate::value::Value;
 
 pub fn parse(
     uri: Option<&String>,
     text: &str,
 ) -> Result<Map<String, Value>, Box<dyn Error + Send + Sync>> {
     // Parse a TOML value from the provided text
-    // TODO: Have a proper error fire if the root of a file is ever not a Table
     let value = from_toml_value(uri, &toml::from_str(text)?);
-    match value.kind {
-        ValueKind::Table(map) => Ok(map),
-
-        _ => Ok(Map::new()),
-    }
+    format::extract_root_table(uri, value)
 }
 
 fn from_toml_value(uri: Option<&String>, value: &toml::Value) -> Value {

--- a/src/file/format/yaml.rs
+++ b/src/file/format/yaml.rs
@@ -4,6 +4,7 @@ use std::mem;
 
 use yaml_rust as yaml;
 
+use crate::format;
 use crate::map::Map;
 use crate::value::{Value, ValueKind};
 
@@ -21,13 +22,8 @@ pub fn parse(
         }
     };
 
-    // TODO: Have a proper error fire if the root of a file is ever not a Table
     let value = from_yaml_value(uri, &root)?;
-    match value.kind {
-        ValueKind::Table(map) => Ok(map),
-
-        _ => Ok(Map::new()),
-    }
+    format::extract_root_table(uri, value)
 }
 
 fn from_yaml_value(


### PR DESCRIPTION
Presently there is an approach implemented for JSON5, while other parsers have a TODO comment. I adapted the approach used for the [Dhall config support](https://github.com/mehcode/config-rs/pull/466) and leveraged it as a common method for `ValueKind`.

AFAIK, the initial parser call for the `text` value into a `from_*` method will handle any earlier failure, while this ensures that `parse()` returns the expected map from `ValueKind::Table`. I think this satisfies the TODO?