### PR TITLE
Clippy exact toolchains

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -96,7 +96,7 @@ jobs:
       matrix:
         rust:
           - 1.66.0
-          - stable
+          - 1.73.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4.1.0
@@ -118,7 +118,7 @@ jobs:
       matrix:
         rust:
           - 1.66.0
-          - stable
+          - 1.73.0
 
     steps:
       - name: Checkout sources

--- a/examples/async_source/main.rs
+++ b/examples/async_source/main.rs
@@ -68,7 +68,7 @@ impl<F: Format + Send + Sync + Debug> AsyncSource for HttpSource<F> {
             .and_then(|text| {
                 self.format
                     .parse(Some(&self.uri), &text)
-                    .map_err(|e| ConfigError::Foreign(e))
+                    .map_err(ConfigError::Foreign)
             })
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -225,7 +225,7 @@ impl ConfigBuilder<DefaultState> {
                     .state
                     .sources
                     .into_iter()
-                    .map(|s| SourceType::Sync(s))
+                    .map(SourceType::Sync)
                     .collect(),
             },
             defaults: self.defaults,

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -128,7 +128,7 @@ where
         let (uri, contents, format) = match self
             .source
             .resolve(self.format.clone())
-            .map_err(|err| ConfigError::Foreign(err))
+            .map_err(ConfigError::Foreign)
         {
             Ok(result) => (result.uri, result.content, result.format),
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -152,6 +152,8 @@ where
 
 impl Display for ValueKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use std::fmt::Write;
+
         match *self {
             Self::String(ref value) => write!(f, "{}", value),
             Self::Boolean(value) => write!(f, "{}", value),
@@ -161,15 +163,20 @@ impl Display for ValueKind {
             Self::U128(value) => write!(f, "{}", value),
             Self::Float(value) => write!(f, "{}", value),
             Self::Nil => write!(f, "nil"),
-            Self::Table(ref table) => write!(f, "{{ {} }}", {
-                table
-                    .iter()
-                    .map(|(k, v)| format!("{} => {}, ", k, v))
-                    .collect::<String>()
-            }),
-            Self::Array(ref array) => write!(f, "{:?}", {
-                array.iter().map(|e| format!("{}, ", e)).collect::<String>()
-            }),
+            Self::Table(ref table) => {
+                let mut s = String::new();
+                for (k, v) in table.iter() {
+                    write!(s, "{} => {}, ", k, v)?
+                }
+                write!(f, "{{ {s} }}")
+            }
+            Self::Array(ref array) => {
+                let mut s = String::new();
+                for e in array.iter() {
+                    write!(s, "{}, ", e)?;
+                }
+                write!(f, "{s:?}")
+            }
         }
     }
 }

--- a/tests/async_builder.rs
+++ b/tests/async_builder.rs
@@ -31,7 +31,7 @@ impl AsyncSource for AsyncFile {
 
         self.format
             .parse(Some(&self.path), &text)
-            .map_err(|e| ConfigError::Foreign(e))
+            .map_err(ConfigError::Foreign)
     }
 }
 


### PR DESCRIPTION
This PR changes the CI job to use clippy at a exact toolchain version only, so the toolchain updates do not break CI for us anymore.