### PR TITLE
refactor: Use a common `from_value` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["toml", "json", "yaml", "ini", "ron", "json5", "convert-case", "async"]
 json = ["serde_json"]
-yaml = ["yaml-rust"]
+yaml = ["serde_yaml"]
 ini = ["rust-ini"]
 json5 = ["json5_rs", "serde/derive"]
 convert-case = ["convert_case"]
@@ -33,7 +33,7 @@ nom = "7"
 async-trait = { version = "0.1.50", optional = true }
 toml = { version = "0.8", optional = true }
 serde_json = { version = "1.0.2", optional = true }
-yaml-rust = { version = "0.4", optional = true }
+serde_yaml  = { version = "0.9", optional = true }
 rust-ini = { version = "0.19", optional = true }
 ron = { version = "0.8", optional = true }
 json5_rs = { version = "0.4", optional = true, package = "json5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ async = ["async-trait"]
 [dependencies]
 lazy_static = "1.0"
 serde = "1.0.8"
+serde_with = "3"
 nom = "7"
 
 async-trait = { version = "0.1.50", optional = true }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [JSON]: https://github.com/serde-rs/json
 [TOML]: https://github.com/toml-lang/toml
-[YAML]: https://github.com/chyh1990/yaml-rust
+[YAML]: https://github.com/dtolnay/serde-yaml
 [INI]: https://github.com/zonyitoo/rust-ini
 [RON]: https://github.com/ron-rs/ron
 [JSON5]: https://github.com/callum-oakley/json5-rs

--- a/src/file/format/json.rs
+++ b/src/file/format/json.rs
@@ -2,53 +2,13 @@ use std::error::Error;
 
 use crate::format;
 use crate::map::Map;
-use crate::value::{Value, ValueKind};
+use crate::value::Value;
 
 pub fn parse(
     uri: Option<&String>,
     text: &str,
 ) -> Result<Map<String, Value>, Box<dyn Error + Send + Sync>> {
-    // Parse a JSON object value from the text
-    let value = from_json_value(uri, &serde_json::from_str(text)?);
+    // Parse a JSON input from the provided text
+    let value = format::from_parsed_value(uri, serde_json::from_str(text)?);
     format::extract_root_table(uri, value)
-}
-
-fn from_json_value(uri: Option<&String>, value: &serde_json::Value) -> Value {
-    match *value {
-        serde_json::Value::String(ref value) => Value::new(uri, ValueKind::String(value.clone())),
-
-        serde_json::Value::Number(ref value) => {
-            if let Some(value) = value.as_i64() {
-                Value::new(uri, ValueKind::I64(value))
-            } else if let Some(value) = value.as_f64() {
-                Value::new(uri, ValueKind::Float(value))
-            } else {
-                unreachable!();
-            }
-        }
-
-        serde_json::Value::Bool(value) => Value::new(uri, ValueKind::Boolean(value)),
-
-        serde_json::Value::Object(ref table) => {
-            let mut m = Map::new();
-
-            for (key, value) in table {
-                m.insert(key.clone(), from_json_value(uri, value));
-            }
-
-            Value::new(uri, ValueKind::Table(m))
-        }
-
-        serde_json::Value::Array(ref array) => {
-            let mut l = Vec::new();
-
-            for value in array {
-                l.push(from_json_value(uri, value));
-            }
-
-            Value::new(uri, ValueKind::Array(l))
-        }
-
-        serde_json::Value::Null => Value::new(uri, ValueKind::Nil),
-    }
 }

--- a/src/file/format/json5.rs
+++ b/src/file/format/json5.rs
@@ -2,53 +2,13 @@ use std::error::Error;
 
 use crate::format;
 use crate::map::Map;
-use crate::value::{Value, ValueKind};
-
-#[derive(serde::Deserialize, Debug)]
-#[serde(untagged)]
-pub enum Val {
-    Null,
-    Boolean(bool),
-    Integer(i64),
-    Float(f64),
-    String(String),
-    Array(Vec<Self>),
-    Object(Map<String, Self>),
-}
+use crate::value::Value;
 
 pub fn parse(
     uri: Option<&String>,
     text: &str,
 ) -> Result<Map<String, Value>, Box<dyn Error + Send + Sync>> {
-    let value = from_json5_value(uri, json5_rs::from_str::<Val>(text)?);
+    // Parse a JSON5 input from the provided text
+    let value = format::from_parsed_value(uri, json5_rs::from_str(text)?);
     format::extract_root_table(uri, value)
-}
-
-fn from_json5_value(uri: Option<&String>, value: Val) -> Value {
-    let vk = match value {
-        Val::Null => ValueKind::Nil,
-        Val::String(v) => ValueKind::String(v),
-        Val::Integer(v) => ValueKind::I64(v),
-        Val::Float(v) => ValueKind::Float(v),
-        Val::Boolean(v) => ValueKind::Boolean(v),
-        Val::Object(table) => {
-            let m = table
-                .into_iter()
-                .map(|(k, v)| (k, from_json5_value(uri, v)))
-                .collect();
-
-            ValueKind::Table(m)
-        }
-
-        Val::Array(array) => {
-            let l = array
-                .into_iter()
-                .map(|v| from_json5_value(uri, v))
-                .collect();
-
-            ValueKind::Array(l)
-        }
-    };
-
-    Value::new(uri, vk)
 }

--- a/src/file/format/mod.rs
+++ b/src/file/format/mod.rs
@@ -40,7 +40,7 @@ pub enum FileFormat {
     #[cfg(feature = "json")]
     Json,
 
-    /// YAML (parsed with yaml_rust)
+    /// YAML (parsed with serde_yaml)
     #[cfg(feature = "yaml")]
     Yaml,
 

--- a/src/file/format/ron.rs
+++ b/src/file/format/ron.rs
@@ -2,62 +2,12 @@ use std::error::Error;
 
 use crate::format;
 use crate::map::Map;
-use crate::value::{Value, ValueKind};
+use crate::value::Value;
 
 pub fn parse(
     uri: Option<&String>,
     text: &str,
 ) -> Result<Map<String, Value>, Box<dyn Error + Send + Sync>> {
-    let value = from_ron_value(uri, ron::from_str(text)?)?;
+    let value = format::from_parsed_value(uri, ron::from_str(text)?);
     format::extract_root_table(uri, value)
-}
-
-fn from_ron_value(
-    uri: Option<&String>,
-    value: ron::Value,
-) -> Result<Value, Box<dyn Error + Send + Sync>> {
-    let kind = match value {
-        ron::Value::Option(value) => match value {
-            Some(value) => from_ron_value(uri, *value)?.kind,
-            None => ValueKind::Nil,
-        },
-
-        ron::Value::Unit => ValueKind::Nil,
-
-        ron::Value::Bool(value) => ValueKind::Boolean(value),
-
-        ron::Value::Number(value) => match value {
-            ron::Number::Float(value) => ValueKind::Float(value.get()),
-            ron::Number::Integer(value) => ValueKind::I64(value),
-        },
-
-        ron::Value::Char(value) => ValueKind::String(value.to_string()),
-
-        ron::Value::String(value) => ValueKind::String(value),
-
-        ron::Value::Seq(values) => {
-            let array = values
-                .into_iter()
-                .map(|value| from_ron_value(uri, value))
-                .collect::<Result<Vec<_>, _>>()?;
-
-            ValueKind::Array(array)
-        }
-
-        ron::Value::Map(values) => {
-            let map = values
-                .iter()
-                .map(|(key, value)| -> Result<_, Box<dyn Error + Send + Sync>> {
-                    let key = key.clone().into_rust::<String>()?;
-                    let value = from_ron_value(uri, value.clone())?;
-
-                    Ok((key, value))
-                })
-                .collect::<Result<Map<_, _>, _>>()?;
-
-            ValueKind::Table(map)
-        }
-    };
-
-    Ok(Value::new(uri, kind))
 }

--- a/src/file/format/toml.rs
+++ b/src/file/format/toml.rs
@@ -2,43 +2,13 @@ use std::error::Error;
 
 use crate::format;
 use crate::map::Map;
-use crate::value::{Value, ValueKind};
+use crate::value::Value;
 
 pub fn parse(
     uri: Option<&String>,
     text: &str,
 ) -> Result<Map<String, Value>, Box<dyn Error + Send + Sync>> {
     // Parse a TOML input from the provided text
-    let value = from_toml_value(uri, toml::from_str(text)?);
+    let value = format::from_parsed_value(uri, toml::from_str(text)?);
     format::extract_root_table(uri, value)
-}
-
-fn from_toml_value(uri: Option<&String>, value: toml::Value) -> Value {
-    let vk = match value {
-        toml::Value::Datetime(v) => ValueKind::String(v.to_string()),
-        toml::Value::String(v)   => ValueKind::String(v),
-        toml::Value::Float(v)    => ValueKind::Float(v),
-        toml::Value::Integer(v)  => ValueKind::I64(v),
-        toml::Value::Boolean(v)  => ValueKind::Boolean(v),
-
-        toml::Value::Table(table) => {
-            let m = table
-                .into_iter()
-                .map(|(k, v)| (k, from_toml_value(uri, v)))
-                .collect();
-
-            ValueKind::Table(m)
-        }
-
-        toml::Value::Array(array) => {
-            let l = array
-                .into_iter()
-                .map(|v| from_toml_value(uri, v))
-                .collect();
-
-            ValueKind::Array(l)
-        }
-    };
-
-    Value::new(uri, vk)
 }

--- a/src/file/format/yaml.rs
+++ b/src/file/format/yaml.rs
@@ -1,105 +1,14 @@
 use std::error::Error;
-use std::fmt;
-use std::mem;
-
-use yaml_rust as yaml;
 
 use crate::format;
 use crate::map::Map;
-use crate::value::{Value, ValueKind};
+use crate::value::Value;
 
 pub fn parse(
     uri: Option<&String>,
     text: &str,
 ) -> Result<Map<String, Value>, Box<dyn Error + Send + Sync>> {
-    // Parse a YAML object from file
-    let mut docs = yaml::YamlLoader::load_from_str(text)?;
-    let root = match docs.len() {
-        0 => yaml::Yaml::Hash(yaml::yaml::Hash::new()),
-        1 => mem::replace(&mut docs[0], yaml::Yaml::Null),
-        n => {
-            return Err(Box::new(MultipleDocumentsError(n)));
-        }
-    };
-
-    let value = from_yaml_value(uri, &root)?;
+    // Parse a YAML input from the provided text
+    let value = format::from_parsed_value(uri, serde_yaml::from_str(text)?);
     format::extract_root_table(uri, value)
-}
-
-fn from_yaml_value(
-    uri: Option<&String>,
-    value: &yaml::Yaml,
-) -> Result<Value, Box<dyn Error + Send + Sync>> {
-    match *value {
-        yaml::Yaml::String(ref value) => Ok(Value::new(uri, ValueKind::String(value.clone()))),
-        yaml::Yaml::Real(ref value) => {
-            // TODO: Figure out in what cases this can panic?
-            value
-                .parse::<f64>()
-                .map_err(|_| {
-                    Box::new(FloatParsingError(value.to_string())) as Box<(dyn Error + Send + Sync)>
-                })
-                .map(ValueKind::Float)
-                .map(|f| Value::new(uri, f))
-        }
-        yaml::Yaml::Integer(value) => Ok(Value::new(uri, ValueKind::I64(value))),
-        yaml::Yaml::Boolean(value) => Ok(Value::new(uri, ValueKind::Boolean(value))),
-        yaml::Yaml::Hash(ref table) => {
-            let mut m = Map::new();
-            for (key, value) in table {
-                match key {
-                    yaml::Yaml::String(k) => m.insert(k.to_owned(), from_yaml_value(uri, value)?),
-                    yaml::Yaml::Integer(k) => m.insert(k.to_string(), from_yaml_value(uri, value)?),
-                    _ => unreachable!(),
-                };
-            }
-            Ok(Value::new(uri, ValueKind::Table(m)))
-        }
-        yaml::Yaml::Array(ref array) => {
-            let mut l = Vec::new();
-
-            for value in array {
-                l.push(from_yaml_value(uri, value)?);
-            }
-
-            Ok(Value::new(uri, ValueKind::Array(l)))
-        }
-
-        // 1. Yaml NULL
-        // 2. BadValue – It shouldn't be possible to hit BadValue as this only happens when
-        //               using the index trait badly or on a type error but we send back nil.
-        // 3. Alias – No idea what to do with this and there is a note in the lib that its
-        //            not fully supported yet anyway
-        _ => Ok(Value::new(uri, ValueKind::Nil)),
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
-struct MultipleDocumentsError(usize);
-
-impl fmt::Display for MultipleDocumentsError {
-    fn fmt(&self, format: &mut fmt::Formatter) -> fmt::Result {
-        write!(format, "Got {} YAML documents, expected 1", self.0)
-    }
-}
-
-impl Error for MultipleDocumentsError {
-    fn description(&self) -> &str {
-        "More than one YAML document provided"
-    }
-}
-
-#[derive(Debug, Clone)]
-struct FloatParsingError(String);
-
-impl fmt::Display for FloatParsingError {
-    fn fmt(&self, format: &mut fmt::Formatter) -> fmt::Result {
-        write!(format, "Parsing {} as floating point number failed", self.0)
-    }
-}
-
-impl Error for FloatParsingError {
-    fn description(&self) -> &str {
-        "Floating point number parsing failed"
-    }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -121,23 +121,16 @@ where
         // Anything that can deserialize into a string successfully:
         String(String),
         // Config specific support for types that need string conversion:
+        Char(char),
         #[cfg(feature = "toml")]
         TomlDateTime(toml::value::Datetime),
-        #[cfg(feature = "ron")]
-        RonChar(ron::Value),
     }
 
     match ParsedString::deserialize(deserializer)? {
         ParsedString::String(v) => Ok(v),
+        ParsedString::Char(v) => Ok(v.to_string()),
         #[cfg(feature = "toml")]
         ParsedString::TomlDateTime(v) => Ok(v.to_string()),
-        #[cfg(feature = "ron")]
-        ParsedString::RonChar(variant) => match variant {
-            ron::Value::Char(v) => Ok(v.to_string()),
-            _ => Err(serde::de::Error::custom(
-                "should not be serialized to string",
-            )),
-        },
     }
 }
 

--- a/tests/file_yaml.rs
+++ b/tests/file_yaml.rs
@@ -81,12 +81,13 @@ fn test_error_parse() {
 
     let path_with_extension: PathBuf = ["tests", "Settings-invalid.yaml"].iter().collect();
 
+    // Should fail to parse block mapping as no `:` exists to identify a key
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
         format!(
-            "while parsing a block mapping, did not find expected key at \
-         line 2 column 1 in {}",
+            "could not find expected ':' at line 3 column 1, \
+            while scanning a simple key at line 2 column 1 in {}",
             path_with_extension.display()
         )
     );

--- a/tests/legacy/file_yaml.rs
+++ b/tests/legacy/file_yaml.rs
@@ -81,12 +81,13 @@ fn test_error_parse() {
 
     let path_with_extension: PathBuf = ["tests", "Settings-invalid.yaml"].iter().collect();
 
+    // Should fail to parse block mapping as no `:` exists to identify a key
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
         format!(
-            "while parsing a block mapping, did not find expected key at \
-         line 2 column 1 in {}",
+            "could not find expected ':' at line 3 column 1, \
+            while scanning a simple key at line 2 column 1 in {}",
             path_with_extension.display()
         )
     );


### PR DESCRIPTION
Inspired from the `json5` feature (_Original PR July 2020, revised PR May 2021_) with the refactoring in the revision by @matthiasbeyer 

It looked useful for other formats that use `serde` to simplify their logic (_so long as test coverage is informative of no issues_ 🙏 )

---

DRY: The `json`, `json5` and `toml` parsers all leverage `serde` and can share a common enum to deserialize data into, instead of individual methods performing roughly the same transformations.

- While `ron` improves their support for serde untagged enums with v0.9, ~~it is still not compatible with this approach (_Their README details why_).~~ (_**UPDATE:** At least for the current `config-rs` test coverage, this appears to be passing now_)
- The `yaml` support doesn't leverage `serde` thus is not compatible. (_**UPDATE:** Since there is talk about the unmaintained status, it could be switched for [`serde-yaml`](https://github.com/dtolnay/serde-yaml), I've verified it can pass the tests with an extra deserializer method_)

`from_parsed_value()` is based on the approached used by `format/json5.rs`:
- It has been adjusted to reflect the `ValueKind` enum, which could not directly be used due to the `Table` and `Array` types using `Value` as their value storage type instead of self-referencing the enum.
- Very similar to a `impl From`, but supports the complimentary `uri` parameter for each `Value` derived.

---

Resolves: https://github.com/mehcode/config-rs/pull/394