### PR TITLE
chore: Update dependencies (`Cargo.toml`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,33 +25,31 @@ preserve_order = ["indexmap", "toml?/preserve_order", "serde_json?/preserve_orde
 async = ["async-trait"]
 
 [dependencies]
-lazy_static = "1.0"
-serde = "1.0.8"
+lazy_static = "1.4"
+serde = "1.0"
 nom = "7"
 
-async-trait = { version = "0.1.50", optional = true }
+async-trait = { version = "0.1", optional = true }
 toml = { version = "0.8", optional = true }
-serde_json = { version = "1.0.2", optional = true }
+serde_json = { version = "1.0", optional = true }
 yaml-rust = { version = "0.4", optional = true }
 rust-ini = { version = "0.19", optional = true }
 ron = { version = "0.8", optional = true }
 json5_rs = { version = "0.4", optional = true, package = "json5" }
-indexmap = { version = "2.0.0", features = ["serde"], optional = true }
+indexmap = { version = "2.0", features = ["serde"], optional = true }
 convert_case = { version = "0.6", optional = true }
 pathdiff = "0.2"
 
 [dev-dependencies]
-serde_derive = "1.0.8"
+serde_derive = "1.0"
 float-cmp = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util", "time"]}
-warp = "=0.3.6"
-futures = "0.3.15"
-reqwest = "0.11.10"
+warp = "0.3"
+futures = "0.3"
+reqwest = "0.11"
 
-serde = "1.0"
 glob = "0.3"
-lazy_static = "1"
-notify = "^6.0.0"
-temp-env = "0.3.0"
+notify = "6.0"
+temp-env = "0.3"
 log = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
Consistently omit patch version.

Package notes:
- `lazy_static` to `1.4` (_note that [this crate is deprecated officially](https://github.com/rust-lang-nursery/lazy-static.rs/issues/214), in favor of [`once_cell`](https://github.com/matklad/once_cell)_).
- `warp`:
  - Previously fixed to a specific version `=` in [Nov 2021 due to concern with MSRV](https://github.com/mehcode/config-rs/pull/249)
  - [Bumped in Sep 2022](https://github.com/mehcode/config-rs/pull/271#issuecomment-1237938950) despite no response from issue raised to the `warp` maintainer.
  - [Mar 2022 comment](https://github.com/seanmonstar/warp/issues/948#issuecomment-1068847073) states `warp` MSRV was 1.51 at the time, which is also when "const generics" feature was introduced (March 2021).
- Removed duplicates of `serde` and `lazy_static` [were repeated in `dev-dependencies` for some reason in Dec 2021](https://github.com/mehcode/config-rs/pull/253). That also added `notify` with the `^` qualifier, but [this is the implicit default](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements) and stripped away from dependencies in this project some time ago.

---

<details>
<summary>Outdated (not likely helpful)</summary>

**UPDATE:** This information may not be that useful to anyone else, hence the collapsed section. It's mostly been superseded by what I learned when preparing https://github.com/mehcode/config-rs/pull/495

Other MSRV history since the March 2022 `warp` reference:
  - In March 2022 `config-rs` documented a version bump of [MSRV from 1.49 to 1.56](https://github.com/mehcode/config-rs/pull/304) (Nov 2021).
  - In March 2023 `config-rs` bumped [MSRV from 1.60 to 1.64](https://github.com/mehcode/config-rs/pull/426) (Sep 2022) due to dev-dependency `temp-env`.
  - In September 2023 `config-rs` [bumped MSRV again to 1.66](https://github.com/mehcode/config-rs/pull/455) (Dec 2022), with no documented reason for the requirement this time.

You may want to update `Cargo.toml` to **communicate MSRV** better via [`rust-version`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field).
- **EDIT:** A contributor [expressed reluctance to set an explicit `rust-version`](https://github.com/mehcode/config-rs/pull/483#issuecomment-1775534431). At the very least, the real MSRV required for published crate should be identified, perhaps via [`cargo-msrv`](https://github.com/foresterre/cargo-msrv)?

---

AFAIK, the patch versions have been set often without bumping, and without any actual requirement to make that the minimum patch version. So they are not actually serving much purpose.

Initially I misunderstood these to implicitly be `=` (fixed), hence the original motivation of the PR. As that's not the case, this does raise `lazy_static` to `1.4` as a minimum, which could be reverted. `lazy_static` last [released `1.4` in Aug 2019](https://github.com/rust-lang-nursery/lazy-static.rs/releases/tag/1.4.0), so I don't consider that a concern.

**EDIT:**
- A recent example with one of the projects dependencies releasing with a `major.minor` semver dependency of their own, and that dependency later pushing out a point release with a feature only stabilized since Rust `1.71` (July 2023), which leaked through to `config-rs` CI catching the failure (_but could just as easily slipped through like for `rust-ini` if the timing was a little later with the `ordered-multimap` crate patch release?_ 🤷‍♂️ )
- There was [another recent one with `ahash`](https://github.com/mehcode/config-rs/issues/491) too (_[upstream issue](https://github.com/tkaitchuck/aHash/issues/174)_), but since resolved.

---

~~Additionally, the `version` field is set to `0.13.1`, while crates reports `0.13.3`?~~ (_**EDIT:** `0.13.x` is maintained via a separate branch, [related PR raised](https://github.com/mehcode/config-rs/pull/495)_)

Another possible update is the [`edition` to 2021](https://doc.rust-lang.org/stable/edition-guide/rust-2021/index.html) 🤷‍♂️ 

</details>
