### PR TITLE
[release-0.13.x] Update MSRV to 1.63.0

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.61.0
+          - 1.63.0
           - stable
           - beta
           - nightly
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.61.0
+          - 1.63.0
           - stable
           - beta
           - nightly
@@ -61,14 +61,14 @@ jobs:
           override: true
 
       - name: Run cargo test
-        if: matrix.rust != 'nightly' && matrix.rust != '1.61.0'
+        if: matrix.rust != 'nightly' && matrix.rust != '1.63.0'
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features
 
       - name: Run cargo test (nightly)
-        if: matrix.rust == '1.61.0'
+        if: matrix.rust == '1.63.0'
         continue-on-error: true
         uses: actions-rs/cargo@v1
         with:
@@ -121,7 +121,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.61.0
+          toolchain: 1.63.0
           override: true
           components: clippy
 
@@ -138,7 +138,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.61.0
+          - 1.63.0
           - stable
 
     steps:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.59.0
+          - 1.60.0
           - stable
           - beta
           - nightly
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.59.0
+          - 1.60.0
           - stable
           - beta
           - nightly
@@ -61,14 +61,14 @@ jobs:
           override: true
 
       - name: Run cargo test
-        if: matrix.rust != 'nightly' && matrix.rust != '1.59.0'
+        if: matrix.rust != 'nightly' && matrix.rust != '1.60.0'
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features
 
       - name: Run cargo test (nightly)
-        if: matrix.rust == '1.59.0'
+        if: matrix.rust == '1.60.0'
         continue-on-error: true
         uses: actions-rs/cargo@v1
         with:
@@ -121,7 +121,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.59.0
+          toolchain: 1.60.0
           override: true
           components: clippy
 
@@ -138,7 +138,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.59.0
+          - 1.60.0
           - stable
 
     steps:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0
+          - 1.61.0
           - stable
           - beta
           - nightly
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0
+          - 1.61.0
           - stable
           - beta
           - nightly
@@ -61,14 +61,14 @@ jobs:
           override: true
 
       - name: Run cargo test
-        if: matrix.rust != 'nightly' && matrix.rust != '1.60.0'
+        if: matrix.rust != 'nightly' && matrix.rust != '1.61.0'
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features
 
       - name: Run cargo test (nightly)
-        if: matrix.rust == '1.60.0'
+        if: matrix.rust == '1.61.0'
         continue-on-error: true
         uses: actions-rs/cargo@v1
         with:
@@ -121,7 +121,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.60.0
+          toolchain: 1.61.0
           override: true
           components: clippy
 
@@ -138,7 +138,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0
+          - 1.61.0
           - stable
 
     steps:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ more usage information.
 
 ## MSRV
 
-We currently support Rust 1.61.0 and newer.
+We currently support Rust 1.63.0 and newer.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ more usage information.
 
 ## MSRV
 
-We currently support Rust 1.60.0 and newer.
+We currently support Rust 1.61.0 and newer.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ more usage information.
 
 ## MSRV
 
-We currently support Rust 1.56.0 and newer.
+We currently support Rust 1.60.0 and newer.
 
 
 ## License

--- a/src/error.rs
+++ b/src/error.rs
@@ -137,7 +137,7 @@ impl ConfigError {
     fn prepend(self, segment: &str, add_dot: bool) -> Self {
         let concat = |key: Option<String>| {
             let key = key.unwrap_or_default();
-            let dot = if add_dot && key.as_bytes().get(0).unwrap_or(&b'[') != &b'[' {
+            let dot = if add_dot && key.as_bytes().first().unwrap_or(&b'[') != &b'[' {
                 "."
             } else {
                 ""


### PR DESCRIPTION
Foe the next 0.13.x release, we need a newer MSRV, because the `log` dependency does not build with 1.59.0 anymore.

So we update the MSRV here.