### PR TITLE
Update MSRV: 1.70.0 -> 1.75.0

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.70.0
+          toolchain: 1.75.0
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
@@ -31,7 +31,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.70.0
+          toolchain: 1.75.0
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
@@ -50,7 +50,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.70.0
+          toolchain: 1.75.0
           components: rustfmt
 
       - name: Run cargo fmt
@@ -68,7 +68,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.70.0
+          toolchain: 1.75.0
           components: clippy
 
       - name: Cache

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ more usage information.
 
 ## MSRV
 
-We currently support Rust 1.70.0 and newer.
+We currently support Rust 1.75.0 and newer.
 
 
 ## License


### PR DESCRIPTION
MSRV is then 1.75.0, which is current stable as of today... but as we just released 0.14.0 and most likely won't release 0.15.0 anytime soon (at least not in the next few weeks I guess), updating to the _current_ stable is okay, because it won't be current when we release 0.15.0.