### PR TITLE
Added BOM sniffing check to file load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "convert_case",
+ "encoding_rs_io",
  "float-cmp",
  "futures",
  "glob",
@@ -319,6 +320,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ async = ["async-trait"]
 lazy_static = "1.4"
 serde = "1.0"
 nom = "7"
+encoding_rs_io = "0.1"
 
 async-trait = { version = "0.1", optional = true }
 toml = { version = "0.8", optional = true }


### PR DESCRIPTION
On Windows, config files will run into an error loading due to a [Byte-order mark](https://en.wikipedia.org/wiki/Byte_order_mark) that may appear at the start. I don't understand this fully, but we would run into an issue from it below:

<img width="803" alt="image" src="https://github.com/mehcode/config-rs/assets/14791619/0410a583-79e1-4882-85e2-cb86501d89c0">

Where a file would load just fine on Mac/Linux, but show this on Windows. This fix will detect this zero-width mark, and properly skip it.