### PR TITLE
Support real values as keys in Yaml hashes

### DIFF
--- a/src/file/format/yaml.rs
+++ b/src/file/format/yaml.rs
@@ -50,6 +50,7 @@ fn from_yaml_value(
                 match key {
                     yaml::Yaml::String(k) => m.insert(k.to_owned(), from_yaml_value(uri, value)?),
                     yaml::Yaml::Integer(k) => m.insert(k.to_string(), from_yaml_value(uri, value)?),
+                    yaml::Yaml::Real(k) => m.insert(k.to_owned(), from_yaml_value(uri, value)?),
                     _ => unreachable!(),
                 };
             }


### PR DESCRIPTION
This PR adds support for real numbers as keys in Yaml hashes, in addition to strings and integers.