### PR TITLE
Custom path parser that doesn't use `nom`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,6 @@ dependencies = [
  "json5",
  "lazy_static",
  "log",
- "nom",
  "notify",
  "pathdiff",
  "reqwest",
@@ -856,12 +855,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,16 +909,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,6 @@ async = ["async-trait"]
 [dependencies]
 lazy_static = "1.4"
 serde = "1.0"
-nom = "7"
-
 async-trait = { version = "0.1", optional = true }
 toml = { version = "0.8", optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,9 +46,9 @@ pub enum ConfigError {
     NotFound(String),
 
     /// Configuration path could not be parsed.
-    PathParse(nom::error::ErrorKind),
+    PathParse(String),
 
-    /// Configuration could not be parsed from file.
+    /// Configuration could not be parsed from a file.
     FileParse {
         /// The URI used to access the file (if not loaded from a string).
         /// Example: `/path/to/config.json`
@@ -187,11 +187,11 @@ impl fmt::Display for ConfigError {
         match *self {
             ConfigError::Frozen => write!(f, "configuration is frozen"),
 
-            ConfigError::PathParse(ref kind) => write!(f, "{}", kind.description()),
+            ConfigError::PathParse(ref kind) => write!(f, "{kind}"),
 
-            ConfigError::Message(ref s) => write!(f, "{}", s),
+            ConfigError::Message(ref s) => write!(f, "{s}"),
 
-            ConfigError::Foreign(ref cause) => write!(f, "{}", cause),
+            ConfigError::Foreign(ref cause) => write!(f, "{cause}"),
 
             ConfigError::NotFound(ref key) => {
                 write!(f, "configuration property {:?} not found", key)

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -17,7 +17,7 @@ impl FromStr for Expression {
     type Err = ConfigError;
 
     fn from_str(s: &str) -> Result<Self> {
-        parser::from_str(s).map_err(ConfigError::PathParse)
+        parser::from_str(s).map_err(|err| ConfigError::PathParse(err.to_string()))
     }
 }
 
@@ -25,7 +25,7 @@ fn sindex_to_uindex(index: isize, len: usize) -> usize {
     if index >= 0 {
         index as usize
     } else {
-        len - (index.abs() as usize)
+        len - index.unsigned_abs()
     }
 }
 

--- a/src/path/parser.rs
+++ b/src/path/parser.rs
@@ -1,83 +1,119 @@
-use std::str::FromStr;
-
-use nom::{
-    branch::alt,
-    bytes::complete::{is_a, tag},
-    character::complete::{char, digit1, space0},
-    combinator::{map, map_res, opt, recognize},
-    error::ErrorKind,
-    sequence::{delimited, pair, preceded},
-    Err, IResult,
-};
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter};
+use std::iter::Peekable;
+use std::num::ParseIntError;
+use std::str::Chars;
 
 use crate::path::Expression;
 
-fn raw_ident(i: &str) -> IResult<&str, String> {
-    map(
-        is_a(
-            "abcdefghijklmnopqrstuvwxyz \
-         ABCDEFGHIJKLMNOPQRSTUVWXYZ \
-         0123456789 \
-         _-",
-        ),
-        ToString::to_string,
-    )(i)
+#[derive(Debug)]
+pub(crate) enum ParseError {
+    ExpectedIdentifier,
+    ExpectedIndex,
+    ExpectedIndexEnd,
+    InvalidInteger(String, ParseIntError),
+    UnexpectedChar(char),
 }
 
-fn integer(i: &str) -> IResult<&str, isize> {
-    map_res(
-        delimited(space0, recognize(pair(opt(tag("-")), digit1)), space0),
-        FromStr::from_str,
-    )(i)
+impl Error for ParseError {}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
+            Self::ExpectedIdentifier => "Expected an identifier".to_string(),
+            Self::ExpectedIndex => "Expected an index".to_string(),
+            Self::ExpectedIndexEnd => "Expected an index to end with ']'".to_string(),
+            Self::InvalidInteger(text, parse_int_error) => {
+                format!("Invalid integer \"{text}\": {parse_int_error}")
+            }
+            Self::UnexpectedChar(c) => format!("Unexpected character '{c}'"),
+        };
+        f.write_str(&msg)
+    }
 }
 
-fn ident(i: &str) -> IResult<&str, Expression> {
-    map(raw_ident, Expression::Identifier)(i)
+fn next_identifier(chars: &mut Peekable<Chars>) -> Result<Option<String>, ParseError> {
+    fn is_identifier_char(c: char) -> bool {
+        c == '-' || c == '_' || c.is_alphabetic() || c.is_ascii_digit()
+    }
+
+    let mut ident = String::with_capacity(16);
+
+    while let Some(&c) = chars.peek() {
+        if is_identifier_char(c) {
+            ident.push(chars.next().unwrap());
+        } else {
+            break;
+        }
+    }
+
+    Ok((!ident.is_empty()).then_some(ident))
 }
 
-fn postfix<'a>(expr: Expression) -> impl FnMut(&'a str) -> IResult<&'a str, Expression> {
-    let e2 = expr.clone();
-    let child = map(preceded(tag("."), raw_ident), move |id| {
-        Expression::Child(Box::new(expr.clone()), id)
-    });
+fn next_integer(chars: &mut Peekable<Chars>) -> Result<Option<isize>, ParseError> {
+    let mut ident = String::with_capacity(8);
 
-    let subscript = map(delimited(char('['), integer, char(']')), move |num| {
-        Expression::Subscript(Box::new(e2.clone()), num)
-    });
+    // May start with a hyphen.
+    match chars.next() {
+        Some(c) if c == '-' || c.is_ascii_digit() => ident.push(c),
+        Some(c) => return Err(ParseError::UnexpectedChar(c)),
+        None => return Err(ParseError::ExpectedIndex),
+    }
 
-    alt((child, subscript))
+    // Rest of the index.
+    while let Some(&c) = chars.peek() {
+        if c == ']' {
+            break;
+        } else if c.is_ascii_digit() {
+            ident.push(chars.next().unwrap());
+        } else {
+            return Err(ParseError::UnexpectedChar(c));
+        }
+    }
+
+    // Must end with a bracket.
+    if chars.next() != Some(']') {
+        return Err(ParseError::ExpectedIndexEnd);
+    }
+
+    if ident.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(
+            ident
+                .parse()
+                .map_err(|err| ParseError::InvalidInteger(ident, err))?,
+        ))
+    }
 }
 
-pub fn from_str(input: &str) -> Result<Expression, ErrorKind> {
-    match ident(input) {
-        Ok((mut rem, mut expr)) => {
-            while !rem.is_empty() {
-                match postfix(expr)(rem) {
-                    Ok((rem_, expr_)) => {
-                        rem = rem_;
-                        expr = expr_;
-                    }
+pub(crate) fn from_str(input: &str) -> Result<Expression, ParseError> {
+    let mut chars = input.chars().peekable();
 
-                    // Forward Incomplete and Error
-                    result => {
-                        return result.map(|(_, o)| o).map_err(to_error_kind);
-                    }
+    // Must start with an identifier.
+    let ident = next_identifier(&mut chars)?;
+    let mut expr = match ident {
+        Some(ident) => Expression::Identifier(ident),
+        None => return Err(ParseError::ExpectedIdentifier),
+    };
+
+    while let Some(c) = chars.next() {
+        expr = match c {
+            '.' => {
+                let ident = next_identifier(&mut chars)?;
+                match ident {
+                    Some(ident) => Expression::Child(Box::new(expr.clone()), ident),
+                    None => return Err(ParseError::ExpectedIdentifier),
                 }
             }
-
-            Ok(expr)
+            '[' => match next_integer(&mut chars)? {
+                Some(index) => Expression::Subscript(Box::new(expr), index),
+                None => return Err(ParseError::ExpectedIndex),
+            },
+            c => return Err(ParseError::UnexpectedChar(c)),
         }
-
-        // Forward Incomplete and Error
-        result => result.map(|(_, o)| o).map_err(to_error_kind),
     }
-}
-
-pub fn to_error_kind(e: Err<nom::error::Error<&str>>) -> ErrorKind {
-    match e {
-        Err::Incomplete(_) => ErrorKind::Complete,
-        Err::Failure(e) | Err::Error(e) => e.code,
-    }
+    Ok(expr)
 }
 
 #[cfg(test)]
@@ -86,46 +122,52 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_id() {
+    fn test_identifier() {
         let parsed: Expression = from_str("abcd").unwrap();
-        assert_eq!(parsed, Identifier("abcd".into()));
+        assert_eq!(parsed, Identifier("abcd".to_string()));
+
+        // Unicode is permitted in identifiers. Identifiers must still be alphabetic.
+        let parsed: Expression = from_str("Öyster").unwrap();
+        assert_eq!(parsed, Identifier("Öyster".to_string()));
     }
 
     #[test]
-    fn test_id_dash() {
+    fn test_identifier_chars() {
         let parsed: Expression = from_str("abcd-efgh").unwrap();
-        assert_eq!(parsed, Identifier("abcd-efgh".into()));
+        assert_eq!(parsed, Identifier("abcd-efgh".to_string()));
+
+        let parsed: Expression = from_str("abcd_efgh").unwrap();
+        assert_eq!(parsed, Identifier("abcd_efgh".to_string()));
     }
 
     #[test]
     fn test_child() {
         let parsed: Expression = from_str("abcd.efgh").unwrap();
-        let expected = Child(Box::new(Identifier("abcd".into())), "efgh".into());
-
+        let expected = Child(Box::new(Identifier("abcd".to_string())), "efgh".to_string());
         assert_eq!(parsed, expected);
 
         let parsed: Expression = from_str("abcd.efgh.ijkl").unwrap();
         let expected = Child(
-            Box::new(Child(Box::new(Identifier("abcd".into())), "efgh".into())),
-            "ijkl".into(),
+            Box::new(Child(
+                Box::new(Identifier("abcd".to_string())),
+                "efgh".to_string(),
+            )),
+            "ijkl".to_string(),
         );
-
         assert_eq!(parsed, expected);
     }
 
     #[test]
     fn test_subscript() {
         let parsed: Expression = from_str("abcd[12]").unwrap();
-        let expected = Subscript(Box::new(Identifier("abcd".into())), 12);
-
+        let expected = Subscript(Box::new(Identifier("abcd".to_string())), 12);
         assert_eq!(parsed, expected);
     }
 
     #[test]
-    fn test_subscript_neg() {
+    fn test_subscript_negative() {
         let parsed: Expression = from_str("abcd[-1]").unwrap();
-        let expected = Subscript(Box::new(Identifier("abcd".into())), -1);
-
+        let expected = Subscript(Box::new(Identifier("abcd".to_string())), -1);
         assert_eq!(parsed, expected);
     }
 }


### PR DESCRIPTION
The path parser was re-written to not use `nom`.  This drops a dependency, benchmarks twice as fast and fixes #516.