### PR TITLE
Switch `yaml-rust2` to `saphyr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +251,7 @@ dependencies = [
  "reqwest",
  "ron",
  "rust-ini",
+ "saphyr",
  "serde",
  "serde_derive",
  "serde_json",
@@ -242,7 +261,6 @@ dependencies = [
  "toml",
  "warp",
  "winnow 0.7.0",
- "yaml-rust2",
 ]
 
 [[package]]
@@ -399,12 +417,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -610,23 +622,18 @@ name = "hashbrown"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
- "foldhash",
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -1574,6 +1581,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "saphyr"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31513a748cdf8fb8d1b64dcc14fdd997fa02f2431671c7ce34efbea5e7eeea"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
+ "saphyr-parser",
+]
+
+[[package]]
+name = "saphyr-parser"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "123f0a6da68f3072c7c761450276d1d444cb391c8be182a757cd26cf684cb77f"
+dependencies = [
+ "arraydeque",
+ "hashlink",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2511,14 +2540,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "yaml-rust2"
-version = "0.10.0"
+name = "zerocopy"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232bdb534d65520716bef0bbb205ff8f2db72d807b19c0bc3020853b92a0cd4b"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "arraydeque",
- "encoding_rs",
- "hashlink",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ pre-release-replacements = [
 [features]
 default = ["toml", "json", "yaml", "ini", "ron", "json5", "convert-case", "async"]
 json = ["serde_json"]
-yaml = ["yaml-rust2"]
+yaml = ["saphyr"]
 ini = ["rust-ini"]
 json5 = ["json5_rs", "serde/derive"]
 convert-case = ["convert_case"]
@@ -127,7 +127,7 @@ serde = "1.0"
 async-trait = { version = "0.1", optional = true }
 toml = { version = "0.8", optional = true, default-features = false, features = ["parse"] }
 serde_json = { version = "1.0", optional = true }
-yaml-rust2 = { version = "0.10", optional = true }
+saphyr = { version = "0.0.3", optional = true }
 rust-ini = { version = "0.21", optional = true }
 ron = { version = "0.8", optional = true }
 json5_rs = { version = "0.4", optional = true, package = "json5" }

--- a/src/file/format/yaml.rs
+++ b/src/file/format/yaml.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fmt;
 use std::mem;
 
-use yaml_rust2 as yaml;
+use saphyr as yaml;
 
 use crate::format;
 use crate::map::Map;
@@ -13,9 +13,9 @@ pub(crate) fn parse(
     text: &str,
 ) -> Result<Map<String, Value>, Box<dyn Error + Send + Sync>> {
     // Parse a YAML object from file
-    let mut docs = yaml::YamlLoader::load_from_str(text)?;
+    let mut docs = yaml::Yaml::load_from_str(text)?;
     let root = match docs.len() {
-        0 => yaml::Yaml::Hash(yaml::yaml::Hash::new()),
+        0 => yaml::Yaml::Hash(yaml::Hash::new()),
         1 => mem::replace(&mut docs[0], yaml::Yaml::Null),
         n => {
             return Err(Box::new(MultipleDocumentsError(n)));


### PR DESCRIPTION
Afaiu the project is still very early in its split so the API changes should not be that much different for now. At least the tests are passing, but please double-check the changes.

Closes: #654