### PR TITLE
chore: `file.rs` - Remove `add_dummy_extension()` helper

### DIFF
--- a/src/file/source/file.rs
+++ b/src/file/source/file.rs
@@ -60,9 +60,12 @@ impl FileSourceFile {
             };
         }
 
-        // Append an extension that will be replaced when calling `set_extension()`:
         let mut filename = filename;
-        filename.as_mut_os_string().push(".ext_placeholder");
+        // Preserve any extension-like text within the provided file stem by appending a fake extension 
+        // which will be replaced by `set_extension()` calls (e.g.  `file.local.placeholder` => `file.local.json`)
+        if filename.extension().is_some() {
+          filename.as_mut_os_string().push(".placeholder");
+        }
 
         match format_hint {
             Some(format) => {


### PR DESCRIPTION
Superseded by https://github.com/rust-cli/config-rs/pull/682

---

The helper method is redundant (_introduced as a [bug fix in Mar 2022](https://github.com/rust-cli/config-rs/pull/306)_), there is a much simpler approach to append the extension.

[`as_mut_os_string()`](https://doc.rust-lang.org/std/path/struct.Path.html#method.as_mut_os_str) has been available since Rust 1.70.0, which fits this crates MSRV that is already leveraging [`OnceLock`](https://doc.rust-lang.org/std/sync/struct.OnceLock.html) (_[since Oct 2024](https://github.com/rust-cli/config-rs/pull/515) / `0.14.1` release_).