### PR TITLE
feat: add corn file format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "glob",
  "indexmap",
  "json5",
+ "libcorn",
  "log",
  "notify",
  "pathdiff",
@@ -1041,6 +1042,20 @@ name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "libcorn"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deeaa03b640fc4dbe8cbc3aadff0e825c994d63b4d99b7589a484029fbd54ae1"
+dependencies = [
+ "cfg-if",
+ "indexmap",
+ "pest",
+ "pest_derive",
+ "serde",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "libredox"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ json = ["serde_json"]
 yaml = ["yaml-rust2"]
 ini = ["rust-ini"]
 json5 = ["json5_rs", "dep:serde-untagged"]
+corn = ["dep:corn"]
 convert-case = ["convert_case"]
 preserve_order = ["indexmap", "toml?/preserve_order", "serde_json?/preserve_order", "ron?/indexmap"]
 async = ["async-trait"]
@@ -141,6 +142,7 @@ yaml-rust2 = { version = "0.10.4", optional = true }
 rust-ini = { version = "0.21.3", optional = true }
 ron = { version = "0.8.1", optional = true }
 json5_rs = { version = "0.4.1", optional = true, package = "json5" }
+corn = { version = "0.10.0", optional = true, package = "libcorn" }
 indexmap = { version = "2.11.4", features = ["serde"], optional = true }
 convert_case = { version = "0.6.0", optional = true }
 pathdiff = "0.2.3"

--- a/src/file/format/corn.rs
+++ b/src/file/format/corn.rs
@@ -1,0 +1,39 @@
+﻿use crate::value::{Value, ValueKind};
+use crate::{format, Map};
+use std::error::Error;
+
+pub(crate) fn parse(
+    uri: Option<&String>,
+    text: &str,
+) -> Result<Map<String, Value>, Box<dyn Error + Send + Sync>> {
+    let value = from_corn_value(uri, &corn::parse(text)?);
+    format::extract_root_table(uri, value)
+}
+
+fn from_corn_value(uri: Option<&String>, value: &corn::Value<'_>) -> Value {
+    match value {
+        corn::Value::String(value) => Value::new(uri, ValueKind::String(value.to_string())),
+        corn::Value::Integer(value) => Value::new(uri, ValueKind::I64(*value)),
+        corn::Value::Float(value) => Value::new(uri, ValueKind::Float(*value)),
+        corn::Value::Boolean(value) => Value::new(uri, ValueKind::Boolean(*value)),
+        corn::Value::Object(value) => Value::new(
+            uri,
+            ValueKind::Table(
+                value
+                    .iter()
+                    .map(|(key, value)| (key.to_string(), from_corn_value(uri, value)))
+                    .collect(),
+            ),
+        ),
+        corn::Value::Array(value) => Value::new(
+            uri,
+            ValueKind::Array(
+                value
+                    .iter()
+                    .map(|value| from_corn_value(uri, value))
+                    .collect(),
+            ),
+        ),
+        corn::Value::Null(_) => Value::new(uri, ValueKind::Nil),
+    }
+}

--- a/src/file/format/mod.rs
+++ b/src/file/format/mod.rs
@@ -21,6 +21,9 @@ mod ron;
 #[cfg(feature = "json5")]
 mod json5;
 
+#[cfg(feature = "corn")]
+mod corn;
+
 /// File formats provided by the library.
 ///
 /// Although it is possible to define custom formats using [`Format`] trait it is recommended to use `FileFormat` if possible.
@@ -50,6 +53,10 @@ pub enum FileFormat {
     /// JSON5 (parsed with json5)
     #[cfg(feature = "json5")]
     Json5,
+
+    /// Corn (parsed with `libcorn`)
+    #[cfg(feature = "corn")]
+    Corn,
 }
 
 impl FileFormat {
@@ -67,6 +74,8 @@ impl FileFormat {
             FileFormat::Ron,
             #[cfg(feature = "json5")]
             FileFormat::Json5,
+            #[cfg(feature = "corn")]
+            FileFormat::Corn,
         ]
     }
 
@@ -89,6 +98,9 @@ impl FileFormat {
 
             #[cfg(feature = "json5")]
             FileFormat::Json5 => &["json5"],
+
+            #[cfg(feature = "corn")]
+            FileFormat::Corn => &["corn"],
 
             #[cfg(all(
                 not(feature = "toml"),
@@ -125,6 +137,9 @@ impl FileFormat {
 
             #[cfg(feature = "json5")]
             FileFormat::Json5 => json5::parse(uri, text),
+
+            #[cfg(feature = "corn")]
+            FileFormat::Corn => corn::parse(uri, text),
 
             #[cfg(all(
                 not(feature = "toml"),

--- a/tests/testsuite/file_corn.rs
+++ b/tests/testsuite/file_corn.rs
@@ -1,0 +1,327 @@
+#![cfg(feature = "corn")]
+
+use chrono::{DateTime, TimeZone, Utc};
+use float_cmp::ApproxEqUlps;
+use serde::Deserialize;
+use snapbox::{assert_data_eq, str};
+
+use config::{Config, File, FileFormat, Map, Value};
+
+#[test]
+fn test_file() {
+    #[derive(Debug, Deserialize)]
+    struct Settings {
+        debug: f64,
+        production: Option<String>,
+        place: Place,
+        #[serde(rename = "arr")]
+        elements: Vec<String>,
+        nullable: Option<String>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Place {
+        name: String,
+        longitude: f64,
+        latitude: f64,
+        favorite: bool,
+        telephone: Option<String>,
+        reviews: u64,
+        creator: Map<String, Value>,
+        rating: Option<f32>,
+    }
+
+    let c = Config::builder()
+        .add_source(File::from_str(
+            r#"
+{
+  // c
+  debug = true
+  production = false
+  arr = [1 2 3 4 5 6 7 8 9 10]
+  place = {
+    name = "Torre di Pisa"
+    longitude = 43.7224985
+    latitude =10.3970522
+    favorite=  false
+    reviews = 3866
+    rating = 4.5
+    creator = {
+      name = "John Smith"
+      username = "jsmith"
+      email = "jsmith@localhost"
+    }
+  }
+  FOO = "FOO should be overridden"
+  bar = "I am bar"
+  nullable = null
+}
+"#,
+            FileFormat::Corn,
+        ))
+        .build()
+        .unwrap();
+
+    // Deserialize the entire file as single struct
+    let s: Settings = c.try_deserialize().unwrap();
+
+    assert!(s.debug.approx_eq_ulps(&1.0, 2));
+    assert_eq!(s.production, Some("false".to_owned()));
+    assert_eq!(s.place.name, "Torre di Pisa");
+    assert!(s.place.longitude.approx_eq_ulps(&43.722_498_5, 2));
+    assert!(s.place.latitude.approx_eq_ulps(&10.397_052_2, 2));
+    assert!(!s.place.favorite);
+    assert_eq!(s.place.reviews, 3866);
+    assert_eq!(s.place.rating, Some(4.5));
+    assert_eq!(s.place.telephone, None);
+    assert_eq!(s.elements.len(), 10);
+    assert_eq!(s.elements[3], "4".to_owned());
+    if cfg!(feature = "preserve_order") {
+        assert_eq!(
+            s.place
+                .creator
+                .into_iter()
+                .collect::<Vec<(String, Value)>>(),
+            vec![
+                ("name".to_owned(), "John Smith".into()),
+                ("username".into(), "jsmith".into()),
+                ("email".into(), "jsmith@localhost".into()),
+            ]
+        );
+    } else {
+        assert_eq!(
+            s.place.creator["name"].clone().into_string().unwrap(),
+            "John Smith".to_owned()
+        );
+    }
+    assert_eq!(s.nullable, None);
+}
+
+#[test]
+fn test_error_parse() {
+    let res = Config::builder()
+        .add_source(File::from_str(
+            r#"
+{
+  ok = true
+  error
+}
+"#,
+            FileFormat::Corn,
+        ))
+        .build();
+
+    assert!(res.is_err());
+    assert_data_eq!(
+        res.unwrap_err().to_string(),
+        str![[r#"
+ --> 4:3
+  |
+4 |   error
+  |   ^---
+  |
+  = expected spread or quoted_path_seg
+"#]]
+    );
+}
+
+#[test]
+fn test_override_uppercase_value_for_struct() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct StructSettings {
+        foo: String,
+        bar: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    #[allow(non_snake_case)]
+    struct CapSettings {
+        FOO: String,
+    }
+
+    std::env::set_var("APP_FOO", "I HAVE BEEN OVERRIDDEN_WITH_UPPER_CASE");
+
+    let cfg = Config::builder()
+        .add_source(File::from_str(
+            r#"
+{
+  // c
+  debug = true
+  production = false
+  arr = [1 2 3 4 5 6 7 8 9 10]
+  place = {
+    name = "Torre di Pisa"
+    longitude = 43.7224985
+    latitude = 10.3970522
+    favorite = false
+    reviews = 3866
+    rating = 4.5
+    creator = {
+      name = "John Smith"
+      username = "jsmith"
+      email = "jsmith@localhost"
+    }
+  }
+  FOO = "FOO should be overridden"
+  bar = "I am bar"
+}
+"#,
+            FileFormat::Corn,
+        ))
+        .add_source(config::Environment::with_prefix("APP").separator("_"))
+        .build()
+        .unwrap();
+
+    let cap_settings = cfg.clone().try_deserialize::<CapSettings>();
+    let lower_settings = cfg.try_deserialize::<StructSettings>().unwrap();
+
+    match cap_settings {
+        Ok(v) => {
+            // this assertion will ensure that the map has only lowercase keys
+            assert_eq!(v.FOO, "FOO should be overridden");
+            assert_eq!(
+                lower_settings.foo,
+                "I HAVE BEEN OVERRIDDEN_WITH_UPPER_CASE".to_owned()
+            );
+        }
+        Err(e) => {
+            if e.to_string().contains("missing field `FOO`") {
+                assert_eq!(
+                    lower_settings.foo,
+                    "I HAVE BEEN OVERRIDDEN_WITH_UPPER_CASE".to_owned()
+                );
+            } else {
+                panic!("{}", e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_override_lowercase_value_for_struct() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct StructSettings {
+        foo: String,
+        bar: String,
+    }
+
+    std::env::set_var("config_foo", "I have been overridden_with_lower_case");
+
+    let cfg = Config::builder()
+        .add_source(File::from_str(
+            r#"
+{
+  // c
+  debug = true
+  production = false
+  arr = [1 2 3 4 5 6 7 8 9 10]
+  place = {
+    name = "Torre di Pisa"
+    longitude = 43.7224985
+    latitude = 10.3970522
+    favorite = false
+    reviews = 3866
+    rating = 4.5
+    creator = {
+      name = "John Smith"
+      username = "jsmith"
+      email = "jsmith@localhost"
+    }
+  }
+  FOO = "FOO should be overridden"
+  bar = "I am bar"
+}
+"#,
+            FileFormat::Corn,
+        ))
+        .add_source(config::Environment::with_prefix("config").separator("_"))
+        .build()
+        .unwrap();
+
+    let values: StructSettings = cfg.try_deserialize().unwrap();
+    assert_eq!(
+        values.foo,
+        "I have been overridden_with_lower_case".to_owned()
+    );
+    assert_eq!(values.bar, "I am bar".to_owned());
+}
+
+#[test]
+fn test_override_uppercase_value_for_enums() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    enum EnumSettings {
+        Bar(String),
+    }
+
+    std::env::set_var("APPS_BAR", "I HAVE BEEN OVERRIDDEN_WITH_UPPER_CASE");
+
+    let cfg = Config::builder()
+        .add_source(File::from_str(
+            r#"
+{
+    bar = "bar is a lowercase param"
+}
+"#,
+            FileFormat::Corn,
+        ))
+        .add_source(config::Environment::with_prefix("APPS").separator("_"))
+        .build()
+        .unwrap();
+
+    let param = cfg.try_deserialize::<EnumSettings>();
+    assert!(param.is_err());
+    assert_data_eq!(
+        param.unwrap_err().to_string(),
+        str!["enum EnumSettings does not have variant constructor bar"]
+    );
+}
+
+#[test]
+fn test_override_lowercase_value_for_enums() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    enum EnumSettings {
+        Bar(String),
+    }
+
+    std::env::set_var("test_bar", "I have been overridden_with_lower_case");
+
+    let cfg = Config::builder()
+        .add_source(File::from_str(
+            r#"
+{
+    bar = "bar is a lowercase param"
+}
+"#,
+            FileFormat::Corn,
+        ))
+        .add_source(config::Environment::with_prefix("test").separator("_"))
+        .build()
+        .unwrap();
+
+    let param = cfg.try_deserialize::<EnumSettings>();
+    assert!(param.is_err());
+    assert_data_eq!(
+        param.unwrap_err().to_string(),
+        str!["enum EnumSettings does not have variant constructor bar"]
+    );
+}
+
+#[test]
+fn corn() {
+    let s = Config::builder()
+        .add_source(File::from_str(
+            r#"
+            {
+                corn_datetime = "2017-05-10T02:14:53Z"
+            }
+            "#,
+            FileFormat::Corn,
+        ))
+        .build()
+        .unwrap();
+
+    let date: String = s.get("corn_datetime").unwrap();
+    assert_eq!(&date, "2017-05-10T02:14:53Z");
+    let date: DateTime<Utc> = s.get("corn_datetime").unwrap();
+    assert_eq!(date, Utc.with_ymd_and_hms(2017, 5, 10, 2, 14, 53).unwrap());
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -8,6 +8,7 @@ pub mod empty;
 pub mod env;
 pub mod errors;
 pub mod file;
+pub mod file_corn;
 pub mod file_ini;
 pub mod file_json;
 pub mod file_json5;


### PR DESCRIPTION
This adds `corn` as a new file format.

I've enabled it by default as per the current standards, but did see discussion in #621 as to possibly changing this approach.

https://cornlang.dev