### PR TITLE
bugfix : problems with compiling ron and base64 on nix rustc 1.92.0-nightly (839222065 2025-10-05)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,15 +122,8 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+source = "git+https://github.com/meta-introspector/rust-base64?branch=feature/CRQ-016-nixify#42e6caba1738c795528415cf25d63d9a01e49c3b"
 
 [[package]]
 name = "bitflags"
@@ -209,6 +202,7 @@ name = "config"
 version = "0.15.18"
 dependencies = [
  "async-trait",
+ "base64",
  "chrono",
  "convert_case",
  "float-cmp",
@@ -586,7 +580,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "headers-core",
  "http",
@@ -679,7 +673,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1299,7 +1293,7 @@ version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "http",
@@ -1327,15 +1321,15 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+version = "0.11.0"
+source = "git+https://github.com/meta-introspector/ron-rs?branch=feature/CRQ-016-nixify#69e3e50fe62bfcf3f3eb565fa1f51628fb4dc88a"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "bitflags 2.9.4",
  "indexmap",
  "serde",
  "serde_derive",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2344,3 +2338,13 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[patch.unused]]
+name = "time"
+version = "0.3.44"
+source = "git+https://github.com/meta-introspector/time-rs?branch=feature/CRQ-016-nixify#fc540559c2a091744eb58947faa0b87493ca624b"
+
+[[patch.unused]]
+name = "time-macros"
+version = "0.2.24"
+source = "git+https://github.com/meta-introspector/time-rs?branch=feature/CRQ-016-nixify#fc540559c2a091744eb58947faa0b87493ca624b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,10 @@ toml = { version = "0.9.6", optional = true, default-features = false, features 
 serde_json = { version = "1.0.145", optional = true }
 yaml-rust2 = { version = "0.10.4", optional = true }
 rust-ini = { version = "0.21.3", optional = true }
-ron = { version = "0.8.1", optional = true }
+#ron = { version = "0.8.1", optional = true }
+base64 = { branch = "feature/CRQ-016-nixify",      git = "https://github.com/meta-introspector/rust-base64" }
+ron = { branch = "feature/CRQ-016-nixify",      git = "https://github.com/meta-introspector/ron-rs" , optional = true }
+
 json5_rs = { version = "0.4.1", optional = true, package = "json5" }
 corn = { version = "0.10.0", optional = true, package = "libcorn" }
 indexmap = { version = "2.11.4", features = ["serde"], optional = true }
@@ -170,3 +173,9 @@ required-features = ["json", "async"]
 
 [lints]
 workspace = true
+
+[patch.crates-io]
+time-macros = { git = "https://github.com/meta-introspector/time-rs", branch = "feature/CRQ-016-nixify", features = [ "default", "formatting", "large-dates",   "parsing",   "serde" ] }
+time = { git = "https://github.com/meta-introspector/time-rs", branch = "feature/CRQ-016-nixify", features = [  "default", "alloc", "formatting", "large-dates", "local-offset", "macros", "parsing", "quickcheck", "serde-human-readable", "serde-well-known", "std", "rand", "serde",  "wasm-bindgen"] }
+base64 = { branch = "feature/CRQ-016-nixify",      git = "https://github.com/meta-introspector/rust-base64" }
+ron = { branch = "feature/CRQ-016-nixify",      git = "https://github.com/meta-introspector/ron-rs" }

--- a/src/file/format/ron.rs
+++ b/src/file/format/ron.rs
@@ -24,11 +24,29 @@ fn from_ron_value(
 
         ron::Value::Unit => ValueKind::Nil,
 
+        ron::Value::Bytes(value) => ValueKind::String(String::from_utf8_lossy(&value).into_owned()),
+
         ron::Value::Bool(value) => ValueKind::Boolean(value),
 
-        ron::Value::Number(value) => match value {
-            ron::Number::Float(value) => ValueKind::Float(value.get()),
-            ron::Number::Integer(value) => ValueKind::I64(value),
+        ron::Value::Number(value) => {
+            match value {
+                ron::Number::I8(v) => ValueKind::I64(v as i64),
+                ron::Number::I16(v) => ValueKind::I64(v as i64),
+                ron::Number::I32(v) => ValueKind::I64(v as i64),
+                ron::Number::I64(v) => ValueKind::I64(v),
+                #[cfg(feature = "integer128")]
+                ron::Number::I128(v) => ValueKind::I64(v as i64),
+                ron::Number::U8(v) => ValueKind::I64(v as i64),
+                ron::Number::U16(v) => ValueKind::I64(v as i64),
+                ron::Number::U32(v) => ValueKind::I64(v as i64),
+                ron::Number::U64(v) => ValueKind::I64(v as i64),
+                #[cfg(feature = "integer128")]
+                ron::Number::U128(v) => ValueKind::I64(v as i64),
+                ron::Number::F32(v) => ValueKind::Float(v.get() as f64),
+                ron::Number::F64(v) => ValueKind::Float(v.get()),
+                #[cfg(not(doc))]
+                ron::Number::__NonExhaustive(never) => never.never(),
+            }
         },
 
         ron::Value::Char(value) => ValueKind::String(value.to_string()),


### PR DESCRIPTION
using a recent compiler nix rustc 1.92.0-nightly (839222065 2025-10-05) on nix with latest version of ron (because of base64 also breaking)

```
Compiling config v0.15.18 (/data/data/com.termux.nix/files/home/pick-up-nix2/vendor/nix/cargo2nix/vendor/config-rs)
error[E0599]: no variant or associated item named `Float` found for enum `ron::Number` in the current scope
  --> src/file/format/ron.rs:30:26
   |
30 |             ron::Number::Float(value) => ValueKind::Float(value.get()),
   |                          ^^^^^ variant or associated item not found in `ron::Number`

error[E0599]: no variant or associated item named `Integer` found for enum `ron::Number` in the current scope
  --> src/file/format/ron.rs:31:26
   |
31 |             ron::Number::Integer(value) => ValueKind::I64(value),
   |                          ^^^^^^^ variant or associated item not found in `ron::Number`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `config` (lib) due to 2 previous errors
```
