### PR TITLE
Refactoring env var case convert to convert each segment between separator

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -296,7 +296,11 @@ impl Source for Environment {
 
             #[cfg(feature = "convert-case")]
             if let Some(convert_case) = convert_case {
-                key = key.to_case(*convert_case);
+                key = key
+                    .split('.')
+                    .map(|segment| segment.to_case(*convert_case))
+                    .collect::<Vec<_>>()
+                    .join(".");
             }
 
             let value = if self.try_parsing {

--- a/tests/testsuite/env.rs
+++ b/tests/testsuite/env.rs
@@ -518,6 +518,32 @@ fn test_parse_string_and_list_ignore_list_parse_key_case() {
     );
 }
 
+#[cfg(feature = "convert-case")]
+fn build_convert_case_config(case: config::Case) -> Config {
+    temp_env::with_vars(
+        vec![
+            ("PREFIX__SINGLE", Some("test")),
+            ("PREFIX__PLAIN__VAL", Some("simple")),
+            ("PREFIX__VALUE_WITH_MULTIPART_NAME", Some("value1")),
+            (
+                "PREFIX__INNER_CONFIG__ANOTHER_MULTIPART_NAME",
+                Some("value2"),
+            ),
+        ],
+        || {
+            Config::builder()
+                .add_source(
+                    Environment::default()
+                        .prefix("PREFIX")
+                        .convert_case(case)
+                        .separator("__"),
+                )
+                .build()
+                .unwrap()
+        },
+    )
+}
+
 #[test]
 #[cfg(feature = "convert-case")]
 fn test_parse_nested_kebab() {
@@ -544,34 +570,50 @@ fn test_parse_nested_kebab() {
         another_multipart_name: String,
     }
 
-    temp_env::with_vars(
-        vec![
-            ("PREFIX__SINGLE", Some("test")),
-            ("PREFIX__PLAIN__VAL", Some("simple")),
-            ("PREFIX__VALUE_WITH_MULTIPART_NAME", Some("value1")),
-            (
-                "PREFIX__INNER_CONFIG__ANOTHER_MULTIPART_NAME",
-                Some("value2"),
-            ),
-        ],
-        || {
-            let environment = Environment::default()
-                .prefix("PREFIX")
-                .convert_case(Case::Kebab)
-                .separator("__");
+    let config: TestConfig = build_convert_case_config(Case::Kebab)
+        .try_deserialize()
+        .unwrap();
 
-            let config = Config::builder().add_source(environment).build().unwrap();
+    assert_eq!(config.single, "test");
+    assert_eq!(config.plain.val, "simple");
+    assert_eq!(config.value_with_multipart_name, "value1");
+    assert_eq!(config.inner_config.another_multipart_name, "value2");
+}
 
-            println!("{config:#?}");
+#[test]
+#[cfg(feature = "convert-case")]
+fn test_parse_pascal() {
+    use config::Case;
 
-            let config: TestConfig = config.try_deserialize().unwrap();
+    #[derive(Deserialize, Debug)]
+    #[serde(rename_all = "PascalCase")]
+    struct TestConfig {
+        single: String,
+        plain: SimpleInner,
+        value_with_multipart_name: String,
+        inner_config: ComplexInner,
+    }
 
-            assert_eq!(config.single, "test");
-            assert_eq!(config.plain.val, "simple");
-            assert_eq!(config.value_with_multipart_name, "value1");
-            assert_eq!(config.inner_config.another_multipart_name, "value2");
-        },
-    );
+    #[derive(Deserialize, Debug)]
+    #[serde(rename_all = "PascalCase")]
+    struct SimpleInner {
+        val: String,
+    }
+
+    #[derive(Deserialize, Debug)]
+    #[serde(rename_all = "PascalCase")]
+    struct ComplexInner {
+        another_multipart_name: String,
+    }
+
+    let config: TestConfig = build_convert_case_config(Case::Pascal)
+        .try_deserialize()
+        .unwrap();
+
+    assert_eq!(config.single, "test");
+    assert_eq!(config.plain.val, "simple");
+    assert_eq!(config.value_with_multipart_name, "value1");
+    assert_eq!(config.inner_config.another_multipart_name, "value2");
 }
 
 #[test]


### PR DESCRIPTION
Currently, it looks like when you are parsing the environment variables into the config and you have some key with multiple segments separated by the ., (key1.key2.key3) when you do the case convert for a case like Pascal, it will result in (Key1.key2.key3). I am not sure if this is intended, because I would think the result should be (Key1.Key2.Key3), where each segment is individually case converted.

This PR aims to refactor the case conversion to convert each segment and not just the first segment.

Also aims to address https://github.com/rust-cli/config-rs/issues/693