### PR TITLE
fix: sort MapAccess entries for deterministic iteration

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -230,9 +230,9 @@ struct MapAccess {
 
 impl MapAccess {
     fn new(table: Map<String, Value>) -> Self {
-        Self {
-            elements: table.into_iter().collect(),
-        }
+        let mut elements: VecDeque<(String, Value)> = table.into_iter().collect();
+        elements.make_contiguous().sort_by_key(|(k, _)| k.clone());
+        Self { elements }
     }
 }
 

--- a/tests/testsuite/env.rs
+++ b/tests/testsuite/env.rs
@@ -804,3 +804,33 @@ mod unicode_tests {
         );
     }
 }
+
+#[test]
+fn test_adjacently_tagged_enum_deterministic() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    #[serde(tag = "type", content = "value")]
+    enum A {
+        V1(u64),
+        V2(String),
+    }
+
+    // Run 20 times to catch non-deterministic HashMap ordering
+    for _ in 0..20 {
+        let config = Config::builder()
+            .add_source(
+                Environment::with_prefix("APP_ADJ_TAG")
+                    .separator("_")
+                    .try_parsing(true)
+                    .source(Some({
+                        let mut env = std::collections::HashMap::new();
+                        env.insert("APP_ADJ_TAG_TYPE".into(), "V1".into());
+                        env.insert("APP_ADJ_TAG_VALUE".into(), "42".into());
+                        env
+                    })),
+            )
+            .build()
+            .unwrap();
+        let a: A = config.try_deserialize().unwrap();
+        assert_eq!(a, A::V1(42));
+    }
+}


### PR DESCRIPTION
## Problem

`HashMap` iteration order is non-deterministic. For adjacently tagged enums like:

```rust
#[serde(tag = "type", content = "value")]
enum A {
    V1(u64),
    V2(String),
}
```

serde needs to see the `type` field before the `value` field to determine the correct variant type. When `HashMap` happens to iterate `value` before `type`, deserialization fails with:

```
invalid type: string "42", expected u64
```

This occurs ~50% of the time due to non-deterministic HashMap ordering.

## Fix

Sort `VecDeque` entries by key in `MapAccess::new`, ensuring deterministic iteration order regardless of `HashMap` internals.

**File:** `src/de.rs` — 3 lines changed

## Testing

Added `test_adjacently_tagged_enum_deterministic` in `tests/testsuite/env.rs` that deserializes an adjacently tagged enum 20 times, catching non-deterministic ordering.

All 147 existing tests + 7 doctests pass.

Closes #720