### PR TITLE
fix(env): apply convert_case to each nested key segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Fixes
+
+- `Environment::convert_case` now applies the case conversion to each nested key segment
+
 ## [0.15.22] - 2026-03-17
 
 ### Documentation

--- a/src/env.rs
+++ b/src/env.rs
@@ -296,7 +296,11 @@ impl Source for Environment {
 
             #[cfg(feature = "convert-case")]
             if let Some(convert_case) = convert_case {
-                key = key.to_case(*convert_case);
+                key = key
+                    .split('.')
+                    .map(|segment| segment.to_case(*convert_case))
+                    .collect::<Vec<_>>()
+                    .join(".");
             }
 
             let value = if self.try_parsing {

--- a/tests/testsuite/env.rs
+++ b/tests/testsuite/env.rs
@@ -575,6 +575,39 @@ fn test_parse_nested_kebab() {
 }
 
 #[test]
+#[cfg(feature = "convert-case")]
+#[should_panic = "missing configuration field"]
+fn test_parse_nested_upper_camel() {
+    use config::Case;
+
+    #[derive(Deserialize, Debug)]
+    struct TestConfig {
+        #[serde(rename = "Otel")]
+        otel: Inner,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct Inner {
+        #[serde(rename = "Endpoint")]
+        endpoint: String,
+    }
+
+    temp_env::with_var("CONFIG_OTEL__ENDPOINT", Some("from env"), || {
+        let environment = Environment::default()
+            .prefix("CONFIG")
+            .prefix_separator("_")
+            .separator("__")
+            .convert_case(Case::UpperCamel);
+
+        let config = Config::builder().add_source(environment).build().unwrap();
+
+        let config: TestConfig = config.try_deserialize().unwrap();
+
+        assert_eq!(config.otel.endpoint, "from env");
+    });
+}
+
+#[test]
 fn test_parse_string() {
     // using a struct in an enum here to make serde use `deserialize_any`
     #[derive(Deserialize, Debug)]

--- a/tests/testsuite/env.rs
+++ b/tests/testsuite/env.rs
@@ -576,7 +576,6 @@ fn test_parse_nested_kebab() {
 
 #[test]
 #[cfg(feature = "convert-case")]
-#[should_panic = "missing configuration field"]
 fn test_parse_nested_upper_camel() {
     use config::Case;
 


### PR DESCRIPTION
When `Environment::convert_case` is combined with `separator`, the case conversion was applied to the whole dotted key at once, so `convert_case` quirks (e.g. `UpperCamel` not capitalizing words after a `.`) produced inconsistent segments like `Otel.endpoint` and broke overrides of file-sourced values. This converts each `.`-separated segment independently. Closes #693