### PR TITLE
fix(ron): map u64 values to ValueKind::U64 instead of lossy I64 cast

### DIFF
--- a/src/file/format/ron.rs
+++ b/src/file/format/ron.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto as _;
 use std::error::Error;
 
 use crate::format;
@@ -37,7 +36,7 @@ fn from_ron_value(
             ron::Number::U8(value) => ValueKind::I64(value.into()),
             ron::Number::U16(value) => ValueKind::I64(value.into()),
             ron::Number::U32(value) => ValueKind::I64(value.into()),
-            ron::Number::U64(value) => ValueKind::I64(value.try_into()?),
+            ron::Number::U64(value) => ValueKind::U64(value),
             _ => Err(crate::ConfigError::Message(
                 "unsupported numeric type".to_owned(),
             ))?,


### PR DESCRIPTION
## Problem

`ron::Number::U64` is currently handled as:

```rust
ron::Number::U64(value) => ValueKind::I64(value.try_into()?),
```

Any `u64` value exceeding `i64::MAX` (~9.2e18) causes a `try_into()` error, silently breaking RON configs that use large unsigned integers.

## Fix

Mirror the pattern applied to the JSON handler in #758:

```rust
ron::Number::U64(value) => ValueKind::U64(value),
```

Also removes the now-unused `use std::convert::TryInto as _;` import — `TryInto` is in the Rust 2021+ prelude, and keeping the import after removing the only `try_into()` call would produce an unused-import warning (CI runs with warnings-as-errors).

## Verification

- `cargo build` — clean, no warnings
- `cargo test` — 166 tests pass (13 unit + 146 integration + 7 doc)